### PR TITLE
Make more props optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,19 +4,19 @@ export type Props = {
     /**
      * Default photo to show.
      */
-    activePhotoIndex: number
+    activePhotoIndex?: number
     /**
      * Executed when a photo is pressed.
      */
-    activePhotoPressed: () => void
+    activePhotoPressed?: () => void
     /**
      * Executed when left key of the keyboard is pressed.
      */
-    leftKeyPressed: () => void
+    leftKeyPressed?: () => void
     /**
      * Called when next control button is pressed.
      */
-    nextButtonPressed: () => void
+    nextButtonPressed?: () => void
     /**
      * Called when the modal is going to close.
      */
@@ -24,11 +24,11 @@ export type Props = {
     /**
      * Preload number photos.
      */
-    preloadSize: number
+    preloadSize?: number
     /**
      * Called when previous control button is pressed.
      */
-    prevButtonPressed: () => void
+    prevButtonPressed?: () => void
     /**
      * Array of photos.
      * It can be an array of photos URLs or an array of objects.


### PR DESCRIPTION
According to https://peterpalau.github.io/react-bnb-gallery/#/getting-started, the only props that are required are:

* `show`
* `photos`
* `onClose`

But the type definition here requires a few more. I've made those optional now.

Without these props being optional, TypeScript throws this error:

```
[tsl] ERROR in /Users/ryanbigg/code/my-app/app/javascript/packs/hello_react.tsx(36,10)
      TS2739: Type '{ activePhotoIndex: number; activePhotoPressed: () => void; show: boolean; photos: any[]; onClose: () => void; }' is missing the following properties from type 'Readonly<Props>': leftKeyPressed, nextButtonPressed, preloadSize, prevButtonPressed
```
