### PR TITLE
Allow React nodes to be passed to caption and subcaption options

### DIFF
--- a/docs/pages/docs/options.mdx
+++ b/docs/pages/docs/options.mdx
@@ -7,7 +7,7 @@ To customize **bnbgallery** you can use the following properties:
 
 ### `activePhotoIndex`
 
-`activePhotoIndex: number` 
+`activePhotoIndex: number`
 
 Initial photo index to show. Defaults to `0`.
 
@@ -125,13 +125,13 @@ The current number of the photo. Defaults to `undefined`.
 
 ### `caption`
 
-`caption: string`
+`caption: string|node`
 
 Photo description. Defaults to `undefined`.
 
 ### `subcaption`
 
-`subcaption: string`
+`subcaption: string|node`
 
 Photo secondary description, like the photo author or the name of the place where it was taken. Defaults to `undefined`.
 

--- a/example/src/pages/Options/Options.js
+++ b/example/src/pages/Options/Options.js
@@ -160,13 +160,13 @@ const Options = () => (
           </tr>
           <tr>
             <td align="left">caption</td>
-            <td align="left"><code className="data-type">string</code></td>
+            <td align="left"><code className="data-type">string|node</code></td>
             <td align="left"><code>undefined</code></td>
             <td align="left">Photo description.</td>
           </tr>
           <tr>
             <td align="left">subcaption</td>
-            <td align="left"><code className="data-type">string</code></td>
+            <td align="left"><code className="data-type">string|node</code></td>
             <td align="left"><code>undefined</code></td>
             <td align="left">Photo secondary description, like the photo author or the name of the place where it was taken.</td>
           </tr>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bnb-gallery",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "description": "Simple photo gallery based on React and Airbnb image gallery",
   "author": "Pedro Enrique Palau <pepalauisaac@gmail.com>",
   "homepage": "https://peterpalau.github.io/react-bnb-gallery/",

--- a/src/shapes/PhotoShape.js
+++ b/src/shapes/PhotoShape.js
@@ -3,7 +3,13 @@ import PropTypes from 'prop-types';
 export default PropTypes.shape({
   photo: PropTypes.string.isRequired,
   number: PropTypes.number,
-  caption: PropTypes.string,
-  subcaption: PropTypes.string,
+  caption: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node
+  ]),
+  subcaption: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node
+  ]),
   thumbnail: PropTypes.string,
 });


### PR DESCRIPTION
This PR allows React nodes to be passed to the `caption` and `subcaption` options of the photo object.

This is useful for when you want to give credit to the author of the photo with a link.


```javascript
{
  // other options...
  subcaption: (
    <span>
      Photo by
        <a href={photo.creditUrl}>
          {photo.creditName}
        </a>
    </span>
  ),
}
```
