### PR TITLE
release: prepare 3.0.0 default-export removal

### DIFF
--- a/.changeset/mean-news-act.md
+++ b/.changeset/mean-news-act.md
@@ -1,0 +1,7 @@
+---
+"react-bnb-gallery": major
+---
+
+Remove all deprecated default exports across the package and keep only named exports.
+
+This finalizes the deprecation path and requires consumers to update imports from default style to named imports.

--- a/README.md
+++ b/README.md
@@ -150,8 +150,7 @@ Prefer these class hooks in custom CSS and tests:
 - `ReactBnbGallery` (recommended)
 - `Gallery`
 - Types: `ReactBnbGalleryProps`, `GalleryPhoto`, `GalleryPhrases`, `GalleryController`
-
-> `default` export is deprecated in `2.x` and will be removed in the next major version.
+- No package `default` export. Use named imports only.
 
 ## Props
 
@@ -227,6 +226,7 @@ pnpm build
 ### `2.1.x`
 
 - Runtime `propTypes` and `airbnb-prop-types` validation were removed.
+- Deprecated default exports were removed. Use named imports only.
 - Added `GalleryPhoto.alt` and `GalleryPhoto.thumbnailAlt` with backward-compatible fallback to `caption`.
 - Added `GalleryPhoto.caption` and `GalleryPhoto.subcaption` support for `ReactNode` content.
 - Deprecated (planned removal next major):

--- a/src/components/caption.tsx
+++ b/src/components/caption.tsx
@@ -141,9 +141,3 @@ function Caption({
 const MemoizedCaption = memo(Caption);
 
 export { MemoizedCaption as Caption };
-
-/**
- * @deprecated Use named import instead: `import { Caption } from './caption'`.
- * Default export will be removed in the next major version.
- */
-export default MemoizedCaption;

--- a/src/components/close-button.tsx
+++ b/src/components/close-button.tsx
@@ -41,9 +41,3 @@ function CloseButton({ onPress, light: _light = false }: CloseButtonProps) {
 }
 
 export { CloseButton };
-
-/**
- * @deprecated Use named import instead: `import { CloseButton } from './close-button'`.
- * Default export will be removed in the next major version.
- */
-export default CloseButton;

--- a/src/components/control.tsx
+++ b/src/components/control.tsx
@@ -58,9 +58,3 @@ function Control({
 const MemoizedControl = memo(Control);
 
 export { MemoizedControl as Control };
-
-/**
- * @deprecated Use named import instead: `import { Control } from './control'`.
- * Default export will be removed in the next major version.
- */
-export default MemoizedControl;

--- a/src/components/gallery.tsx
+++ b/src/components/gallery.tsx
@@ -408,9 +408,3 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 const MemoizedGallery = memo(Gallery);
 
 export { MemoizedGallery as Gallery };
-
-/**
- * @deprecated Use named import instead: `import { Gallery } from './gallery'`.
- * Default export will be removed in the next major version.
- */
-export default MemoizedGallery;

--- a/src/components/image.tsx
+++ b/src/components/image.tsx
@@ -104,9 +104,3 @@ function Image({
 }
 
 export { Image };
-
-/**
- * @deprecated Use named import instead: `import { Image } from './image'`.
- * Default export will be removed in the next major version.
- */
-export default Image;

--- a/src/components/loading-spinner.tsx
+++ b/src/components/loading-spinner.tsx
@@ -17,9 +17,3 @@ function LoadingSpinner({ show = true }: LoadingSpinnerProps) {
 }
 
 export { LoadingSpinner };
-
-/**
- * @deprecated Use named import instead: `import { LoadingSpinner } from './loading-spinner'`.
- * Default export will be removed in the next major version.
- */
-export default LoadingSpinner;

--- a/src/components/next-button.tsx
+++ b/src/components/next-button.tsx
@@ -36,9 +36,3 @@ function NextButton({
 const MemoizedNextButton = memo(NextButton);
 
 export { MemoizedNextButton as NextButton };
-
-/**
- * @deprecated Use named import instead: `import { NextButton } from './next-button'`.
- * Default export will be removed in the next major version.
- */
-export default MemoizedNextButton;

--- a/src/components/photo.tsx
+++ b/src/components/photo.tsx
@@ -75,9 +75,3 @@ function Photo({
 const MemoizedPhoto = memo(Photo);
 
 export { MemoizedPhoto as Photo };
-
-/**
- * @deprecated Use named import instead: `import { Photo } from './photo'`.
- * Default export will be removed in the next major version.
- */
-export default MemoizedPhoto;

--- a/src/components/prev-button.tsx
+++ b/src/components/prev-button.tsx
@@ -36,9 +36,3 @@ function PrevButton({
 const MemoizedPrevButton = memo(PrevButton);
 
 export { MemoizedPrevButton as PrevButton };
-
-/**
- * @deprecated Use named import instead: `import { PrevButton } from './prev-button'`.
- * Default export will be removed in the next major version.
- */
-export default MemoizedPrevButton;

--- a/src/components/thumbnail.tsx
+++ b/src/components/thumbnail.tsx
@@ -64,9 +64,3 @@ function Thumbnail({
 const MemoizedThumbnail = memo(Thumbnail);
 
 export { MemoizedThumbnail as Thumbnail };
-
-/**
- * @deprecated Use named import instead: `import { Thumbnail } from './thumbnail'`.
- * Default export will be removed in the next major version.
- */
-export default MemoizedThumbnail;

--- a/src/components/toggle-photo-list.tsx
+++ b/src/components/toggle-photo-list.tsx
@@ -38,9 +38,3 @@ function TogglePhotoList({
 const MemoizedTogglePhotoList = memo(TogglePhotoList);
 
 export { MemoizedTogglePhotoList as TogglePhotoList };
-
-/**
- * @deprecated Use named import instead: `import { TogglePhotoList } from './toggle-photo-list'`.
- * Default export will be removed in the next major version.
- */
-export default MemoizedTogglePhotoList;

--- a/src/default-phrases.ts
+++ b/src/default-phrases.ts
@@ -14,9 +14,3 @@ export const defaultPhrases = {
 };
 
 export type DefaultPhrases = typeof defaultPhrases;
-
-/**
- * @deprecated Use named import instead: `import { defaultPhrases } from './default-phrases'`.
- * Default export will be removed in the next major version.
- */
-export default defaultPhrases;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,6 @@ import './css/style.css';
 import { Gallery } from './components/gallery';
 import { ReactBnbGallery } from './react-bnb-gallery';
 
-/**
- * @deprecated Use named import instead: `import { ReactBnbGallery } from 'react-bnb-gallery'`.
- * Default export will be removed in the next major version.
- */
-export default ReactBnbGallery;
-
 export { ReactBnbGallery, Gallery };
 
 export type { ReactBnbGalleryProps } from './react-bnb-gallery';

--- a/src/react-bnb-gallery.tsx
+++ b/src/react-bnb-gallery.tsx
@@ -293,9 +293,3 @@ export function ReactBnbGallery({
 		document.body,
 	);
 }
-
-/**
- * @deprecated Use named import instead: `import { ReactBnbGallery } from 'react-bnb-gallery'`.
- * Default export will be removed in the next major version.
- */
-export default ReactBnbGallery;

--- a/src/utils/get-caption-text.ts
+++ b/src/utils/get-caption-text.ts
@@ -11,10 +11,3 @@ export function getCaptionText(caption: ReactNode): string {
 
 	return '';
 }
-
-/**
- * @deprecated Use named import instead:
- * `import { getCaptionText } from './get-caption-text'`.
- * Default export will be removed in the next major version.
- */
-export default getCaptionText;

--- a/src/utils/normalize-photos.ts
+++ b/src/utils/normalize-photos.ts
@@ -30,10 +30,3 @@ export function normalizePhotos(
 	const photosToProcess = Array.isArray(photos) ? photos : [photos];
 	return photosToProcess.map(processPhoto);
 }
-
-/**
- * @deprecated Use named import instead:
- * `import { normalizePhotos } from './normalize-photos'`.
- * Default export will be removed in the next major version.
- */
-export default normalizePhotos;

--- a/src/utils/resolve-phrase.ts
+++ b/src/utils/resolve-phrase.ts
@@ -19,10 +19,3 @@ export function resolvePhrase<T = unknown>(
 
 	return '';
 }
-
-/**
- * @deprecated Use named import instead:
- * `import { resolvePhrase } from './resolve-phrase'`.
- * Default export will be removed in the next major version.
- */
-export default resolvePhrase;

--- a/tests/components/Caption.test.js
+++ b/tests/components/Caption.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-import Caption from '../../src/components/caption';
+import { Caption } from '../../src/components/caption';
 import { calculateThumbnailsLeftScroll } from '../../src/utils/thumbnail-layout';
 
 import photos from '../test-photos';

--- a/tests/components/Gallery.test.js
+++ b/tests/components/Gallery.test.js
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import { vi } from 'vitest';
 
-import Gallery from '../../src/components/gallery';
+import { Gallery } from '../../src/components/gallery';
 
 import photos from '../test-photos';
 

--- a/tests/components/react-bnb-gallery.test.js
+++ b/tests/components/react-bnb-gallery.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react';
 import { vi } from 'vitest';
-import ReactBnbGallery from '../../src/react-bnb-gallery';
+import { ReactBnbGallery } from '../../src/react-bnb-gallery';
 
 import photos from '../test-photos';
 


### PR DESCRIPTION
## Summary
- remove deprecated default exports across library modules
- migrate internal tests to named imports
- update README export guidance for named-import-only usage

## Release impact
- breaking change for consumers using default imports
- intended for the next major release (3.0.0)

## Validation
- pnpm test
- pnpm lint
- pnpm build