### PR TITLE
feat(v3): simplify zoom to gesture-only interactions

### DIFF
--- a/.changeset/eight-rules-beam.md
+++ b/.changeset/eight-rules-beam.md
@@ -1,0 +1,13 @@
+---
+"react-bnb-gallery": minor
+---
+
+Add active-photo zoom and pan support in the gallery viewport.
+
+This introduces opt-in/controlled zoom behavior through new props:
+
+- `enableZoom` (default `true`)
+- `maxZoom` (default `3`)
+- `zoomStep` (default `0.25`)
+
+It also adds built-in zoom controls (`zoom in`, `zoom out`, `reset zoom`) with localizable phrases and prevents swipe/click-next interactions while zoom is active.

--- a/src/components/gallery.tsx
+++ b/src/components/gallery.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, MouseEvent, TouchEvent } from 'react';
+import type { CSSProperties, MouseEvent, TouchEvent, WheelEvent } from 'react';
 import {
 	forwardRef,
 	memo,
@@ -45,6 +45,15 @@ interface GalleryProps {
 
 interface TouchInfo {
 	screenX: number;
+}
+
+interface PinchInfo {
+	startDistance: number;
+	startScale: number;
+	startOffsetX: number;
+	startOffsetY: number;
+	startMidpointX: number;
+	startMidpointY: number;
 }
 
 interface GalleryState {
@@ -144,6 +153,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 	const previousActivePhotoIndexRef = useRef(activePhotoIndex);
 	const panStartRef = useRef({ x: 0, y: 0 });
 	const panOriginRef = useRef({ x: 0, y: 0 });
+	const pinchStartRef = useRef<PinchInfo | null>(null);
 	const [state, setState] = useState<GalleryState>(() => {
 		const normalizedActivePhotoIndex = getNormalizedActivePhotoIndex(
 			activePhotoIndex,
@@ -324,29 +334,62 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 
 	const normalizedMaxZoom = Math.max(MIN_ZOOM, maxZoom);
 	const normalizedZoomStep = Math.max(0.1, zoomStep);
+	const isZoomMode = enableZoom && state.zoomScale > MIN_ZOOM;
 
-	const resetZoom = useCallback(() => {
-		setState((prevState) => ({
-			...prevState,
-			zoomScale: MIN_ZOOM,
-			zoomOffsetX: 0,
-			zoomOffsetY: 0,
-			isPanning: false,
-		}));
-	}, []);
+	const getTouchDistance = useCallback(
+		(
+			touchA: { clientX: number; clientY: number },
+			touchB: {
+				clientX: number;
+				clientY: number;
+			},
+		) => {
+			const deltaX = touchA.clientX - touchB.clientX;
+			const deltaY = touchA.clientY - touchB.clientY;
+			return Math.hypot(deltaX, deltaY);
+		},
+		[],
+	);
 
 	const setZoomScale = useCallback(
-		(nextScale: number) => {
+		(nextScale: number, focalClientX?: number, focalClientY?: number) => {
 			setState((prevState) => {
 				const clampedScale = Math.min(
 					Math.max(nextScale, MIN_ZOOM),
 					normalizedMaxZoom,
 				);
+				if (
+					clampedScale === prevState.zoomScale &&
+					focalClientX === undefined &&
+					focalClientY === undefined
+				) {
+					return prevState;
+				}
+
+				let nextOffsetX = prevState.zoomOffsetX;
+				let nextOffsetY = prevState.zoomOffsetY;
+				const element = photoButtonRef.current;
+
+				if (
+					element &&
+					focalClientX !== undefined &&
+					focalClientY !== undefined &&
+					prevState.zoomScale > 0
+				) {
+					const rect = element.getBoundingClientRect();
+					const focalX = focalClientX - rect.left - rect.width / 2;
+					const focalY = focalClientY - rect.top - rect.height / 2;
+					const scaleRatio = clampedScale / prevState.zoomScale;
+
+					nextOffsetX = (prevState.zoomOffsetX - focalX) * scaleRatio + focalX;
+					nextOffsetY = (prevState.zoomOffsetY - focalY) * scaleRatio + focalY;
+				}
+
 				const nextOffsets = clampZoomOffset(
-					prevState.zoomOffsetX,
-					prevState.zoomOffsetY,
+					nextOffsetX,
+					nextOffsetY,
 					clampedScale,
-					photoButtonRef.current,
+					element,
 				);
 
 				return {
@@ -360,14 +403,6 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 		},
 		[normalizedMaxZoom],
 	);
-
-	const zoomIn = useCallback(() => {
-		setZoomScale(state.zoomScale + normalizedZoomStep);
-	}, [normalizedZoomStep, setZoomScale, state.zoomScale]);
-
-	const zoomOut = useCallback(() => {
-		setZoomScale(state.zoomScale - normalizedZoomStep);
-	}, [normalizedZoomStep, setZoomScale, state.zoomScale]);
 
 	const startPan = useCallback(
 		(clientX: number, clientY: number) => {
@@ -421,12 +456,50 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 
 	const onTouchStart = useCallback(
 		(event: TouchEvent) => {
+			if (!enableZoom) {
+				const touch = event.targetTouches[0];
+				if (!touch) {
+					return;
+				}
+				setState((prevState) => ({
+					...prevState,
+					touchStartInfo: touch,
+				}));
+				return;
+			}
+
+			if (event.targetTouches.length === 2) {
+				const firstTouch = event.targetTouches[0];
+				const secondTouch = event.targetTouches[1];
+				if (!firstTouch || !secondTouch) {
+					return;
+				}
+
+				const startDistance = getTouchDistance(firstTouch, secondTouch);
+				pinchStartRef.current = {
+					startDistance,
+					startScale: state.zoomScale,
+					startOffsetX: state.zoomOffsetX,
+					startOffsetY: state.zoomOffsetY,
+					startMidpointX: (firstTouch.clientX + secondTouch.clientX) / 2,
+					startMidpointY: (firstTouch.clientY + secondTouch.clientY) / 2,
+				};
+				setState((prevState) => ({
+					...prevState,
+					touchMoved: false,
+					touchStartInfo: null,
+					touchEndInfo: null,
+					isPanning: false,
+				}));
+				return;
+			}
+
 			const touch = event.targetTouches[0];
 			if (!touch) {
 				return;
 			}
 
-			if (enableZoom && state.zoomScale > MIN_ZOOM) {
+			if (state.zoomScale > MIN_ZOOM) {
 				startPan(touch.clientX, touch.clientY);
 				return;
 			}
@@ -436,17 +509,99 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 				touchStartInfo: touch,
 			}));
 		},
-		[enableZoom, startPan, state.zoomScale],
+		[
+			enableZoom,
+			getTouchDistance,
+			startPan,
+			state.zoomOffsetX,
+			state.zoomOffsetY,
+			state.zoomScale,
+		],
 	);
 
 	const onTouchMove = useCallback(
 		(event: TouchEvent) => {
+			if (!enableZoom) {
+				const touch = event.targetTouches[0];
+				if (!touch) {
+					return;
+				}
+
+				setState((prevState) => ({
+					...prevState,
+					touchMoved: true,
+					touchEndInfo: touch,
+				}));
+				return;
+			}
+
+			if (event.targetTouches.length === 2 && pinchStartRef.current) {
+				const firstTouch = event.targetTouches[0];
+				const secondTouch = event.targetTouches[1];
+				if (!firstTouch || !secondTouch) {
+					return;
+				}
+
+				event.preventDefault();
+				const pinchStart = pinchStartRef.current;
+				const currentDistance = getTouchDistance(firstTouch, secondTouch);
+				const distanceRatio =
+					pinchStart.startDistance > 0
+						? currentDistance / pinchStart.startDistance
+						: 1;
+				const nextScale = pinchStart.startScale * distanceRatio;
+				const midpointX = (firstTouch.clientX + secondTouch.clientX) / 2;
+				const midpointY = (firstTouch.clientY + secondTouch.clientY) / 2;
+				const midpointDeltaX = midpointX - pinchStart.startMidpointX;
+				const midpointDeltaY = midpointY - pinchStart.startMidpointY;
+				const baseOffsetX = pinchStart.startOffsetX + midpointDeltaX;
+				const baseOffsetY = pinchStart.startOffsetY + midpointDeltaY;
+
+				setState((prevState) => {
+					const clampedScale = Math.min(
+						Math.max(nextScale, MIN_ZOOM),
+						normalizedMaxZoom,
+					);
+					let nextOffsetX = baseOffsetX;
+					let nextOffsetY = baseOffsetY;
+					const element = photoButtonRef.current;
+					if (element && pinchStart.startScale > 0) {
+						const rect = element.getBoundingClientRect();
+						const focalX = midpointX - rect.left - rect.width / 2;
+						const focalY = midpointY - rect.top - rect.height / 2;
+						const scaleRatio = clampedScale / pinchStart.startScale;
+
+						nextOffsetX = (baseOffsetX - focalX) * scaleRatio + focalX;
+						nextOffsetY = (baseOffsetY - focalY) * scaleRatio + focalY;
+					}
+
+					const nextOffsets = clampZoomOffset(
+						nextOffsetX,
+						nextOffsetY,
+						clampedScale,
+						element,
+					);
+
+					return {
+						...prevState,
+						zoomScale: clampedScale,
+						zoomOffsetX: nextOffsets.x,
+						zoomOffsetY: nextOffsets.y,
+						isPanning: false,
+						touchMoved: false,
+						touchStartInfo: null,
+						touchEndInfo: null,
+					};
+				});
+				return;
+			}
+
 			const touch = event.targetTouches[0];
 			if (!touch) {
 				return;
 			}
 
-			if (enableZoom && state.zoomScale > MIN_ZOOM) {
+			if (state.zoomScale > MIN_ZOOM) {
 				event.preventDefault();
 				updatePan(touch.clientX, touch.clientY);
 				return;
@@ -458,10 +613,22 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 				touchEndInfo: touch,
 			}));
 		},
-		[enableZoom, state.zoomScale, updatePan],
+		[
+			getTouchDistance,
+			enableZoom,
+			normalizedMaxZoom,
+			state.zoomScale,
+			updatePan,
+		],
 	);
 
 	const onTouchEnd = useCallback(() => {
+		if (pinchStartRef.current) {
+			pinchStartRef.current = null;
+			endPan();
+			return;
+		}
+
 		if (enableZoom && state.zoomScale > MIN_ZOOM) {
 			endPan();
 			return;
@@ -492,9 +659,12 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 
 	const onMouseDown = useCallback(
 		(event: MouseEvent<HTMLButtonElement>) => {
+			if (isZoomMode) {
+				event.preventDefault();
+			}
 			startPan(event.clientX, event.clientY);
 		},
-		[startPan],
+		[isZoomMode, startPan],
 	);
 
 	const onMouseMove = useCallback(
@@ -511,6 +681,25 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 	const onMouseLeave = useCallback(() => {
 		endPan();
 	}, [endPan]);
+
+	const onWheel = useCallback(
+		(event: WheelEvent<HTMLButtonElement>) => {
+			if (!enableZoom) {
+				return;
+			}
+
+			event.preventDefault();
+			const zoomDirection = event.deltaY < 0 ? 1 : -1;
+			const wheelStepMultiplier = Math.max(
+				1,
+				Math.min(Math.abs(event.deltaY) / 100, 3),
+			);
+			const delta = normalizedZoomStep * wheelStepMultiplier * zoomDirection;
+
+			setZoomScale(state.zoomScale + delta, event.clientX, event.clientY);
+		},
+		[enableZoom, normalizedZoomStep, setZoomScale, state.zoomScale],
+	);
 
 	const to = useCallback(
 		(index: number) => {
@@ -574,72 +763,17 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 		state.hidePrevButton,
 	]);
 
-	const zoomControls = useMemo(() => {
-		if (!enableZoom || photos.length === 0) {
-			return null;
-		}
-
-		const canZoomIn = state.zoomScale < normalizedMaxZoom;
-		const canZoomOut = state.zoomScale > MIN_ZOOM;
-		const isResetDisabled =
-			state.zoomScale === MIN_ZOOM &&
-			state.zoomOffsetX === 0 &&
-			state.zoomOffsetY === 0;
-
-		return (
-			<div className="gallery-zoom-controls">
-				<button
-					type="button"
-					className="gallery-zoom-button gallery-zoom-button--in"
-					onClick={zoomIn}
-					disabled={!canZoomIn}
-					aria-label={phrases.zoomIn}
-				>
-					+
-				</button>
-				<button
-					type="button"
-					className="gallery-zoom-button gallery-zoom-button--out"
-					onClick={zoomOut}
-					disabled={!canZoomOut}
-					aria-label={phrases.zoomOut}
-				>
-					-
-				</button>
-				<button
-					type="button"
-					className="gallery-zoom-button gallery-zoom-button--reset"
-					onClick={resetZoom}
-					disabled={isResetDisabled}
-					aria-label={phrases.resetZoom}
-				>
-					1x
-				</button>
-			</div>
-		);
-	}, [
-		enableZoom,
-		normalizedMaxZoom,
-		phrases.resetZoom,
-		phrases.zoomIn,
-		phrases.zoomOut,
-		photos.length,
-		resetZoom,
-		state.zoomOffsetX,
-		state.zoomOffsetY,
-		state.zoomScale,
-		zoomIn,
-		zoomOut,
-	]);
-
 	const zoomedPhotoStyle = useMemo(
 		() =>
 			({
 				'--rbg-zoom-scale': String(state.zoomScale),
 				'--rbg-pan-x': `${state.zoomOffsetX}px`,
 				'--rbg-pan-y': `${state.zoomOffsetY}px`,
+				'--rbg-zoom-transition': state.isPanning
+					? 'none'
+					: 'transform 180ms ease-out',
 			}) as CSSProperties,
-		[state.zoomOffsetX, state.zoomOffsetY, state.zoomScale],
+		[state.isPanning, state.zoomOffsetX, state.zoomOffsetY, state.zoomScale],
 	);
 
 	const galleryModalPreloadPhotos = useMemo(() => {
@@ -668,7 +802,6 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 			<div className="gallery-modal--preload">{galleryModalPreloadPhotos}</div>
 			<div className="gallery-main">
 				{controls}
-				{zoomControls}
 				<div className="gallery-photos">
 					{hasPhotos ? (
 						<div className="gallery-photo">
@@ -685,8 +818,12 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 									onMouseMove={onMouseMove}
 									onMouseUp={onMouseUp}
 									onMouseLeave={onMouseLeave}
+									onWheel={onWheel}
 									buttonRef={photoButtonRef}
-									disablePress={enableZoom && state.zoomScale > MIN_ZOOM}
+									disablePress={isZoomMode}
+									enableZoom={enableZoom}
+									isZoomMode={isZoomMode}
+									isPanning={state.isPanning}
 									style={zoomedPhotoStyle}
 								/>
 							</div>

--- a/src/components/gallery.tsx
+++ b/src/components/gallery.tsx
@@ -1,4 +1,4 @@
-import type { TouchEvent } from 'react';
+import type { CSSProperties, MouseEvent, TouchEvent } from 'react';
 import {
 	forwardRef,
 	memo,
@@ -6,6 +6,7 @@ import {
 	useEffect,
 	useImperativeHandle,
 	useMemo,
+	useRef,
 	useState,
 } from 'react';
 
@@ -28,7 +29,9 @@ interface GalleryProps {
 	activePhotoIndex?: number;
 	activePhotoPressed?: () => void;
 	direction?: string;
+	enableZoom?: boolean;
 	light?: boolean;
+	maxZoom?: number;
 	nextButtonPressed?: () => void;
 	onActivePhotoIndexChange?: (index: number) => void;
 	phrases?: GalleryPhrases;
@@ -36,6 +39,7 @@ interface GalleryProps {
 	preloadSize?: number;
 	prevButtonPressed?: () => void;
 	showThumbnails?: boolean;
+	zoomStep?: number;
 	wrap?: boolean;
 }
 
@@ -48,12 +52,36 @@ interface GalleryState {
 	hidePrevButton: boolean;
 	hideNextButton: boolean;
 	controlsDisabled: boolean;
+	zoomScale: number;
+	zoomOffsetX: number;
+	zoomOffsetY: number;
+	isPanning: boolean;
 	touchStartInfo: TouchInfo | null;
 	touchEndInfo: TouchInfo | null;
 	touchMoved: boolean;
 }
 
 const EMPTY_PHOTOS: GalleryPhoto[] = [];
+const MIN_ZOOM = 1;
+
+function clampZoomOffset(
+	offsetX: number,
+	offsetY: number,
+	scale: number,
+	element: HTMLElement | null,
+) {
+	if (!element || scale <= MIN_ZOOM) {
+		return { x: 0, y: 0 };
+	}
+
+	const maxX = ((scale - 1) * element.clientWidth) / 2;
+	const maxY = ((scale - 1) * element.clientHeight) / 2;
+
+	return {
+		x: Math.min(Math.max(offsetX, -maxX), maxX),
+		y: Math.min(Math.max(offsetY, -maxY), maxY),
+	};
+}
 
 /**
  * Clamps a requested active index to available photo bounds.
@@ -97,7 +125,9 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 	{
 		activePhotoIndex = 0,
 		activePhotoPressed,
+		enableZoom = true,
 		light = false,
+		maxZoom = 3,
 		nextButtonPressed,
 		onActivePhotoIndexChange,
 		phrases = defaultPhrases,
@@ -105,10 +135,15 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 		preloadSize = 5,
 		prevButtonPressed,
 		showThumbnails = true,
+		zoomStep = 0.25,
 		wrap = false,
 	},
 	ref,
 ) {
+	const photoButtonRef = useRef<HTMLButtonElement | null>(null);
+	const previousActivePhotoIndexRef = useRef(activePhotoIndex);
+	const panStartRef = useRef({ x: 0, y: 0 });
+	const panOriginRef = useRef({ x: 0, y: 0 });
 	const [state, setState] = useState<GalleryState>(() => {
 		const normalizedActivePhotoIndex = getNormalizedActivePhotoIndex(
 			activePhotoIndex,
@@ -124,6 +159,10 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 			hidePrevButton,
 			hideNextButton,
 			controlsDisabled: true,
+			zoomScale: MIN_ZOOM,
+			zoomOffsetX: 0,
+			zoomOffsetY: 0,
+			isPanning: false,
 			touchStartInfo: null,
 			touchEndInfo: null,
 			touchMoved: false,
@@ -162,6 +201,34 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 	useEffect(() => {
 		onActivePhotoIndexChange?.(state.activePhotoIndex);
 	}, [onActivePhotoIndexChange, state.activePhotoIndex]);
+
+	useEffect(() => {
+		const activePhotoChanged =
+			previousActivePhotoIndexRef.current !== state.activePhotoIndex;
+		previousActivePhotoIndexRef.current = state.activePhotoIndex;
+		if (!activePhotoChanged) {
+			return;
+		}
+
+		setState((prevState) => {
+			if (
+				prevState.zoomScale === MIN_ZOOM &&
+				prevState.zoomOffsetX === 0 &&
+				prevState.zoomOffsetY === 0 &&
+				!prevState.isPanning
+			) {
+				return prevState;
+			}
+
+			return {
+				...prevState,
+				zoomScale: MIN_ZOOM,
+				zoomOffsetX: 0,
+				zoomOffsetY: 0,
+				isPanning: false,
+			};
+		});
+	}, [state.activePhotoIndex]);
 
 	const getItemByDirection = useCallback(
 		(direction: string, activeIndex: number) => {
@@ -248,26 +315,158 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 	}, []);
 
 	const onPhotoPress = useCallback(() => {
+		if (enableZoom && state.zoomScale > MIN_ZOOM) {
+			return;
+		}
 		move(DIRECTION_NEXT);
 		activePhotoPressed?.();
-	}, [activePhotoPressed, move]);
+	}, [activePhotoPressed, enableZoom, move, state.zoomScale]);
 
-	const onTouchStart = useCallback((event: TouchEvent) => {
+	const normalizedMaxZoom = Math.max(MIN_ZOOM, maxZoom);
+	const normalizedZoomStep = Math.max(0.1, zoomStep);
+
+	const resetZoom = useCallback(() => {
 		setState((prevState) => ({
 			...prevState,
-			touchStartInfo: event.targetTouches[0],
+			zoomScale: MIN_ZOOM,
+			zoomOffsetX: 0,
+			zoomOffsetY: 0,
+			isPanning: false,
 		}));
 	}, []);
 
-	const onTouchMove = useCallback((event: TouchEvent) => {
-		setState((prevState) => ({
-			...prevState,
-			touchMoved: true,
-			touchEndInfo: event.targetTouches[0],
-		}));
+	const setZoomScale = useCallback(
+		(nextScale: number) => {
+			setState((prevState) => {
+				const clampedScale = Math.min(
+					Math.max(nextScale, MIN_ZOOM),
+					normalizedMaxZoom,
+				);
+				const nextOffsets = clampZoomOffset(
+					prevState.zoomOffsetX,
+					prevState.zoomOffsetY,
+					clampedScale,
+					photoButtonRef.current,
+				);
+
+				return {
+					...prevState,
+					zoomScale: clampedScale,
+					zoomOffsetX: nextOffsets.x,
+					zoomOffsetY: nextOffsets.y,
+					isPanning: clampedScale > MIN_ZOOM ? prevState.isPanning : false,
+				};
+			});
+		},
+		[normalizedMaxZoom],
+	);
+
+	const zoomIn = useCallback(() => {
+		setZoomScale(state.zoomScale + normalizedZoomStep);
+	}, [normalizedZoomStep, setZoomScale, state.zoomScale]);
+
+	const zoomOut = useCallback(() => {
+		setZoomScale(state.zoomScale - normalizedZoomStep);
+	}, [normalizedZoomStep, setZoomScale, state.zoomScale]);
+
+	const startPan = useCallback(
+		(clientX: number, clientY: number) => {
+			if (!enableZoom || state.zoomScale <= MIN_ZOOM) {
+				return;
+			}
+
+			panStartRef.current = { x: clientX, y: clientY };
+			panOriginRef.current = { x: state.zoomOffsetX, y: state.zoomOffsetY };
+
+			setState((prevState) => ({ ...prevState, isPanning: true }));
+		},
+		[enableZoom, state.zoomOffsetX, state.zoomOffsetY, state.zoomScale],
+	);
+
+	const updatePan = useCallback((clientX: number, clientY: number) => {
+		setState((prevState) => {
+			if (!prevState.isPanning) {
+				return prevState;
+			}
+
+			const deltaX = clientX - panStartRef.current.x;
+			const deltaY = clientY - panStartRef.current.y;
+			const nextOffsets = clampZoomOffset(
+				panOriginRef.current.x + deltaX,
+				panOriginRef.current.y + deltaY,
+				prevState.zoomScale,
+				photoButtonRef.current,
+			);
+
+			return {
+				...prevState,
+				zoomOffsetX: nextOffsets.x,
+				zoomOffsetY: nextOffsets.y,
+			};
+		});
 	}, []);
+
+	const endPan = useCallback(() => {
+		setState((prevState) => {
+			if (!prevState.isPanning) {
+				return prevState;
+			}
+
+			return {
+				...prevState,
+				isPanning: false,
+			};
+		});
+	}, []);
+
+	const onTouchStart = useCallback(
+		(event: TouchEvent) => {
+			const touch = event.targetTouches[0];
+			if (!touch) {
+				return;
+			}
+
+			if (enableZoom && state.zoomScale > MIN_ZOOM) {
+				startPan(touch.clientX, touch.clientY);
+				return;
+			}
+
+			setState((prevState) => ({
+				...prevState,
+				touchStartInfo: touch,
+			}));
+		},
+		[enableZoom, startPan, state.zoomScale],
+	);
+
+	const onTouchMove = useCallback(
+		(event: TouchEvent) => {
+			const touch = event.targetTouches[0];
+			if (!touch) {
+				return;
+			}
+
+			if (enableZoom && state.zoomScale > MIN_ZOOM) {
+				event.preventDefault();
+				updatePan(touch.clientX, touch.clientY);
+				return;
+			}
+
+			setState((prevState) => ({
+				...prevState,
+				touchMoved: true,
+				touchEndInfo: touch,
+			}));
+		},
+		[enableZoom, state.zoomScale, updatePan],
+	);
 
 	const onTouchEnd = useCallback(() => {
+		if (enableZoom && state.zoomScale > MIN_ZOOM) {
+			endPan();
+			return;
+		}
+
 		setState((prevState) => {
 			const { touchStartInfo, touchEndInfo, touchMoved } = prevState;
 			if (touchMoved && touchStartInfo && touchEndInfo) {
@@ -283,7 +482,35 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 				touchMoved: false,
 			};
 		});
-	}, [onNextButtonPress, onPrevButtonPress]);
+	}, [
+		enableZoom,
+		endPan,
+		onNextButtonPress,
+		onPrevButtonPress,
+		state.zoomScale,
+	]);
+
+	const onMouseDown = useCallback(
+		(event: MouseEvent<HTMLButtonElement>) => {
+			startPan(event.clientX, event.clientY);
+		},
+		[startPan],
+	);
+
+	const onMouseMove = useCallback(
+		(event: MouseEvent<HTMLButtonElement>) => {
+			updatePan(event.clientX, event.clientY);
+		},
+		[updatePan],
+	);
+
+	const onMouseUp = useCallback(() => {
+		endPan();
+	}, [endPan]);
+
+	const onMouseLeave = useCallback(() => {
+		endPan();
+	}, [endPan]);
 
 	const to = useCallback(
 		(index: number) => {
@@ -347,6 +574,74 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 		state.hidePrevButton,
 	]);
 
+	const zoomControls = useMemo(() => {
+		if (!enableZoom || photos.length === 0) {
+			return null;
+		}
+
+		const canZoomIn = state.zoomScale < normalizedMaxZoom;
+		const canZoomOut = state.zoomScale > MIN_ZOOM;
+		const isResetDisabled =
+			state.zoomScale === MIN_ZOOM &&
+			state.zoomOffsetX === 0 &&
+			state.zoomOffsetY === 0;
+
+		return (
+			<div className="gallery-zoom-controls">
+				<button
+					type="button"
+					className="gallery-zoom-button gallery-zoom-button--in"
+					onClick={zoomIn}
+					disabled={!canZoomIn}
+					aria-label={phrases.zoomIn}
+				>
+					+
+				</button>
+				<button
+					type="button"
+					className="gallery-zoom-button gallery-zoom-button--out"
+					onClick={zoomOut}
+					disabled={!canZoomOut}
+					aria-label={phrases.zoomOut}
+				>
+					-
+				</button>
+				<button
+					type="button"
+					className="gallery-zoom-button gallery-zoom-button--reset"
+					onClick={resetZoom}
+					disabled={isResetDisabled}
+					aria-label={phrases.resetZoom}
+				>
+					1x
+				</button>
+			</div>
+		);
+	}, [
+		enableZoom,
+		normalizedMaxZoom,
+		phrases.resetZoom,
+		phrases.zoomIn,
+		phrases.zoomOut,
+		photos.length,
+		resetZoom,
+		state.zoomOffsetX,
+		state.zoomOffsetY,
+		state.zoomScale,
+		zoomIn,
+		zoomOut,
+	]);
+
+	const zoomedPhotoStyle = useMemo(
+		() =>
+			({
+				'--rbg-zoom-scale': String(state.zoomScale),
+				'--rbg-pan-x': `${state.zoomOffsetX}px`,
+				'--rbg-pan-y': `${state.zoomOffsetY}px`,
+			}) as CSSProperties,
+		[state.zoomOffsetX, state.zoomOffsetY, state.zoomScale],
+	);
+
 	const galleryModalPreloadPhotos = useMemo(() => {
 		let counter = 1;
 		let index = state.activePhotoIndex;
@@ -373,6 +668,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 			<div className="gallery-modal--preload">{galleryModalPreloadPhotos}</div>
 			<div className="gallery-main">
 				{controls}
+				{zoomControls}
 				<div className="gallery-photos">
 					{hasPhotos ? (
 						<div className="gallery-photo">
@@ -385,6 +681,13 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 									onTouchStart={onTouchStart}
 									onTouchMove={onTouchMove}
 									onTouchEnd={onTouchEnd}
+									onMouseDown={onMouseDown}
+									onMouseMove={onMouseMove}
+									onMouseUp={onMouseUp}
+									onMouseLeave={onMouseLeave}
+									buttonRef={photoButtonRef}
+									disablePress={enableZoom && state.zoomScale > MIN_ZOOM}
+									style={zoomedPhotoStyle}
 								/>
 							</div>
 						</div>

--- a/src/components/gallery.tsx
+++ b/src/components/gallery.tsx
@@ -240,7 +240,8 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 		const activePhotoChanged =
 			previousActivePhotoIndexRef.current !== state.activePhotoIndex;
 		previousActivePhotoIndexRef.current = state.activePhotoIndex;
-		if (!activePhotoChanged) {
+		const shouldResetZoom = activePhotoChanged || !enableZoom;
+		if (!shouldResetZoom) {
 			return;
 		}
 
@@ -262,7 +263,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 				isPanning: false,
 			};
 		});
-	}, [state.activePhotoIndex]);
+	}, [enableZoom, state.activePhotoIndex]);
 
 	const getItemByDirection = useCallback(
 		(direction: string, activeIndex: number) => {

--- a/src/components/gallery.tsx
+++ b/src/components/gallery.tsx
@@ -78,13 +78,36 @@ function clampZoomOffset(
 	offsetY: number,
 	scale: number,
 	element: HTMLElement | null,
+	mediaElement: HTMLImageElement | null,
 ) {
-	if (!element || scale <= MIN_ZOOM) {
+	if (!element || !mediaElement || scale <= MIN_ZOOM) {
 		return { x: 0, y: 0 };
 	}
 
-	const maxX = ((scale - 1) * element.clientWidth) / 2;
-	const maxY = ((scale - 1) * element.clientHeight) / 2;
+	const viewportWidth = element.clientWidth;
+	const viewportHeight = element.clientHeight;
+	const intrinsicWidth = mediaElement.naturalWidth || mediaElement.clientWidth;
+	const intrinsicHeight =
+		mediaElement.naturalHeight || mediaElement.clientHeight;
+
+	if (
+		viewportWidth <= 0 ||
+		viewportHeight <= 0 ||
+		intrinsicWidth <= 0 ||
+		intrinsicHeight <= 0
+	) {
+		return { x: 0, y: 0 };
+	}
+
+	const containScale = Math.min(
+		viewportWidth / intrinsicWidth,
+		viewportHeight / intrinsicHeight,
+		1,
+	);
+	const renderedWidth = intrinsicWidth * containScale;
+	const renderedHeight = intrinsicHeight * containScale;
+	const maxX = Math.max(0, (renderedWidth * scale - viewportWidth) / 2);
+	const maxY = Math.max(0, (renderedHeight * scale - viewportHeight) / 2);
 
 	return {
 		x: Math.min(Math.max(offsetX, -maxX), maxX),
@@ -150,6 +173,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 	ref,
 ) {
 	const photoButtonRef = useRef<HTMLButtonElement | null>(null);
+	const photoImageRef = useRef<HTMLImageElement | null>(null);
 	const previousActivePhotoIndexRef = useRef(activePhotoIndex);
 	const panStartRef = useRef({ x: 0, y: 0 });
 	const panOriginRef = useRef({ x: 0, y: 0 });
@@ -390,6 +414,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 					nextOffsetY,
 					clampedScale,
 					element,
+					photoImageRef.current,
 				);
 
 				return {
@@ -431,6 +456,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 				panOriginRef.current.y + deltaY,
 				prevState.zoomScale,
 				photoButtonRef.current,
+				photoImageRef.current,
 			);
 
 			return {
@@ -580,6 +606,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 						nextOffsetY,
 						clampedScale,
 						element,
+						photoImageRef.current,
 					);
 
 					return {
@@ -820,6 +847,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 									onMouseLeave={onMouseLeave}
 									onWheel={onWheel}
 									buttonRef={photoButtonRef}
+									imageRef={photoImageRef}
 									disablePress={isZoomMode}
 									enableZoom={enableZoom}
 									isZoomMode={isZoomMode}

--- a/src/components/image.tsx
+++ b/src/components/image.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { CSSProperties } from 'react';
+import type { CSSProperties, Ref } from 'react';
 import { useEffect, useState } from 'react';
 import { LoadingSpinner } from './loading-spinner';
 
@@ -16,6 +16,7 @@ interface ImageProps {
 	src: string;
 	style?: CSSProperties | null;
 	className?: string | string[] | null;
+	imageRef?: Ref<HTMLImageElement>;
 	onLoad?: () => void;
 	onError?: () => void;
 }
@@ -37,6 +38,7 @@ function Image({
 	src,
 	style = null,
 	className = null,
+	imageRef,
 	onLoad,
 	onError,
 }: ImageProps) {
@@ -91,6 +93,7 @@ function Image({
 			{loading && <LoadingSpinner />}
 			{!withError && (
 				<img
+					ref={imageRef}
 					alt={alt}
 					className={clsx(classNames)}
 					onLoad={handleLoad}

--- a/src/components/photo.tsx
+++ b/src/components/photo.tsx
@@ -29,6 +29,7 @@ interface PhotoProps {
 	onError?: () => void;
 	style?: CSSProperties;
 	buttonRef?: Ref<HTMLButtonElement>;
+	imageRef?: Ref<HTMLImageElement>;
 	disablePress?: boolean;
 	enableZoom?: boolean;
 	isZoomMode?: boolean;
@@ -53,6 +54,7 @@ function Photo({
 	onError,
 	style,
 	buttonRef,
+	imageRef,
 	disablePress = false,
 	enableZoom = true,
 	isZoomMode = false,
@@ -106,6 +108,7 @@ function Photo({
 						onLoad={onLoad}
 						onError={onError}
 						style={style}
+						imageRef={imageRef}
 					/>
 				</button>
 			</li>

--- a/src/components/photo.tsx
+++ b/src/components/photo.tsx
@@ -1,5 +1,11 @@
 import clsx from 'clsx';
-import type { CSSProperties, MouseEvent, Ref, TouchEvent } from 'react';
+import type {
+	CSSProperties,
+	MouseEvent,
+	Ref,
+	TouchEvent,
+	WheelEvent,
+} from 'react';
 import { memo, useCallback } from 'react';
 import type { GalleryPhoto } from '../types/gallery';
 import { getCaptionText } from '../utils/get-caption-text';
@@ -18,11 +24,15 @@ interface PhotoProps {
 	onMouseMove?: (event: MouseEvent<HTMLButtonElement>) => void;
 	onMouseUp?: (event: MouseEvent<HTMLButtonElement>) => void;
 	onMouseLeave?: (event: MouseEvent<HTMLButtonElement>) => void;
+	onWheel?: (event: WheelEvent<HTMLButtonElement>) => void;
 	onLoad?: () => void;
 	onError?: () => void;
 	style?: CSSProperties;
 	buttonRef?: Ref<HTMLButtonElement>;
 	disablePress?: boolean;
+	enableZoom?: boolean;
+	isZoomMode?: boolean;
+	isPanning?: boolean;
 }
 
 /**
@@ -38,11 +48,15 @@ function Photo({
 	onMouseMove,
 	onMouseUp,
 	onMouseLeave,
+	onWheel,
 	onLoad,
 	onError,
 	style,
 	buttonRef,
 	disablePress = false,
+	enableZoom = true,
+	isZoomMode = false,
+	isPanning = false,
 }: PhotoProps) {
 	const onPressHandler = useCallback(() => {
 		if (disablePress) {
@@ -69,7 +83,13 @@ function Photo({
 					ref={buttonRef}
 					type="button"
 					onClick={onPressHandler}
-					className="photo-button gallery-photo-button"
+					className={clsx(
+						'photo-button',
+						'gallery-photo-button',
+						enableZoom && 'gallery-photo-button--zoom-enabled',
+						isZoomMode && 'gallery-photo-button--zoomed',
+						isPanning && 'gallery-photo-button--panning',
+					)}
 					onTouchStart={onTouchStart}
 					onTouchMove={onTouchMove}
 					onTouchEnd={onTouchEnd}
@@ -77,6 +97,7 @@ function Photo({
 					onMouseMove={onMouseMove}
 					onMouseUp={onMouseUp}
 					onMouseLeave={onMouseLeave}
+					onWheel={onWheel}
 				>
 					<Image
 						alt={photo.alt || captionText}

--- a/src/components/photo.tsx
+++ b/src/components/photo.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { CSSProperties, TouchEvent } from 'react';
+import type { CSSProperties, MouseEvent, Ref, TouchEvent } from 'react';
 import { memo, useCallback } from 'react';
 import type { GalleryPhoto } from '../types/gallery';
 import { getCaptionText } from '../utils/get-caption-text';
@@ -14,9 +14,15 @@ interface PhotoProps {
 	onTouchStart?: (event: TouchEvent<HTMLButtonElement>) => void;
 	onTouchMove?: (event: TouchEvent<HTMLButtonElement>) => void;
 	onTouchEnd?: (event: TouchEvent<HTMLButtonElement>) => void;
+	onMouseDown?: (event: MouseEvent<HTMLButtonElement>) => void;
+	onMouseMove?: (event: MouseEvent<HTMLButtonElement>) => void;
+	onMouseUp?: (event: MouseEvent<HTMLButtonElement>) => void;
+	onMouseLeave?: (event: MouseEvent<HTMLButtonElement>) => void;
 	onLoad?: () => void;
 	onError?: () => void;
 	style?: CSSProperties;
+	buttonRef?: Ref<HTMLButtonElement>;
+	disablePress?: boolean;
 }
 
 /**
@@ -28,13 +34,22 @@ function Photo({
 	onTouchStart,
 	onTouchMove,
 	onTouchEnd,
+	onMouseDown,
+	onMouseMove,
+	onMouseUp,
+	onMouseLeave,
 	onLoad,
 	onError,
 	style,
+	buttonRef,
+	disablePress = false,
 }: PhotoProps) {
 	const onPressHandler = useCallback(() => {
+		if (disablePress) {
+			return;
+		}
 		onPress?.();
-	}, [onPress]);
+	}, [disablePress, onPress]);
 
 	if (!photo) {
 		return null;
@@ -51,12 +66,17 @@ function Photo({
 		<ul className="gallery-images--ul gallery-photo-list">
 			<li className={clsx(className, 'gallery-photo-item')}>
 				<button
+					ref={buttonRef}
 					type="button"
 					onClick={onPressHandler}
 					className="photo-button gallery-photo-button"
 					onTouchStart={onTouchStart}
 					onTouchMove={onTouchMove}
 					onTouchEnd={onTouchEnd}
+					onMouseDown={onMouseDown}
+					onMouseMove={onMouseMove}
+					onMouseUp={onMouseUp}
+					onMouseLeave={onMouseLeave}
 				>
 					<Image
 						alt={photo.alt || captionText}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -281,6 +281,9 @@
 
 	.gallery-photo-image,
 	.gallery ul.gallery-images--ul li.gallery-media-photo .picture img.photo {
+		--rbg-zoom-scale: 1;
+		--rbg-pan-x: 0px;
+		--rbg-pan-y: 0px;
 		max-height: 100%;
 		max-width: 100%;
 		position: absolute;
@@ -291,8 +294,11 @@
 		margin: 0 auto;
 		z-index: 0;
 		border-radius: var(--rbg-radius);
-		transform: translateY(-50%);
+		transform: translateY(-50%) translate(var(--rbg-pan-x), var(--rbg-pan-y))
+			scale(var(--rbg-zoom-scale));
+		transform-origin: center center;
 		box-shadow: var(--rbg-photo-shadow);
+		transition: transform 180ms ease-out;
 	}
 
 	@media (max-width: 900px) {
@@ -380,6 +386,41 @@
 			width: 10%;
 			font-size: medium;
 		}
+	}
+
+	/* ─── Zoom controls ───────────────────────────────────────────────────────────── */
+
+	.gallery-zoom-controls {
+		position: absolute;
+		z-index: 4;
+		right: 0.75rem;
+		bottom: 0.75rem;
+		display: inline-flex;
+		gap: 0.35rem;
+	}
+
+	.gallery-zoom-button {
+		cursor: pointer;
+		min-width: 2rem;
+		height: 2rem;
+		border: 0;
+		border-radius: calc(var(--rbg-radius) - 0.125rem);
+		background: rgba(0, 0, 0, 0.55);
+		color: var(--rbg-foreground);
+		font-size: 0.875rem;
+		line-height: 1;
+		padding: 0 0.5rem;
+	}
+
+	.gallery-zoom-button:disabled {
+		opacity: 0.45;
+		cursor: not-allowed;
+	}
+
+	.mode-light .gallery-zoom-button,
+	.rbg-light .gallery-zoom-button {
+		background: rgba(255, 255, 255, 0.82);
+		color: #111;
 	}
 
 	/* ─── Figcaption / caption strip ─────────────────────────────────────────────── */

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -284,6 +284,7 @@
 		--rbg-zoom-scale: 1;
 		--rbg-pan-x: 0px;
 		--rbg-pan-y: 0px;
+		--rbg-zoom-transition: transform 180ms ease-out;
 		max-height: 100%;
 		max-width: 100%;
 		position: absolute;
@@ -298,7 +299,7 @@
 			scale(var(--rbg-zoom-scale));
 		transform-origin: center center;
 		box-shadow: var(--rbg-photo-shadow);
-		transition: transform 180ms ease-out;
+		transition: var(--rbg-zoom-transition);
 	}
 
 	@media (max-width: 900px) {
@@ -318,6 +319,19 @@
 		cursor: pointer;
 		padding: 0;
 		appearance: none;
+	}
+
+	.gallery-photo-button--zoom-enabled {
+		touch-action: none;
+	}
+
+	.gallery-photo-button--zoomed {
+		cursor: grab;
+	}
+
+	.gallery-photo-button--zoomed:active,
+	.gallery-photo-button--panning {
+		cursor: grabbing;
 	}
 
 	.gallery-photo-button:active,
@@ -386,41 +400,6 @@
 			width: 10%;
 			font-size: medium;
 		}
-	}
-
-	/* ─── Zoom controls ───────────────────────────────────────────────────────────── */
-
-	.gallery-zoom-controls {
-		position: absolute;
-		z-index: 4;
-		right: 0.75rem;
-		bottom: 0.75rem;
-		display: inline-flex;
-		gap: 0.35rem;
-	}
-
-	.gallery-zoom-button {
-		cursor: pointer;
-		min-width: 2rem;
-		height: 2rem;
-		border: 0;
-		border-radius: calc(var(--rbg-radius) - 0.125rem);
-		background: rgba(0, 0, 0, 0.55);
-		color: var(--rbg-foreground);
-		font-size: 0.875rem;
-		line-height: 1;
-		padding: 0 0.5rem;
-	}
-
-	.gallery-zoom-button:disabled {
-		opacity: 0.45;
-		cursor: not-allowed;
-	}
-
-	.mode-light .gallery-zoom-button,
-	.rbg-light .gallery-zoom-button {
-		background: rgba(255, 255, 255, 0.82);
-		color: #111;
 	}
 
 	/* ─── Figcaption / caption strip ─────────────────────────────────────────────── */

--- a/src/default-phrases.ts
+++ b/src/default-phrases.ts
@@ -11,12 +11,6 @@ export const defaultPhrases = {
 	showPhotoList: 'Show photo list',
 	/** Label for the button that closes the photo list panel. */
 	hidePhotoList: 'Hide photo list',
-	/** Label for the zoom-in control. */
-	zoomIn: 'Zoom in',
-	/** Label for the zoom-out control. */
-	zoomOut: 'Zoom out',
-	/** Label for the zoom reset control. */
-	resetZoom: 'Reset zoom',
 };
 
 export type DefaultPhrases = typeof defaultPhrases;

--- a/src/default-phrases.ts
+++ b/src/default-phrases.ts
@@ -11,6 +11,12 @@ export const defaultPhrases = {
 	showPhotoList: 'Show photo list',
 	/** Label for the button that closes the photo list panel. */
 	hidePhotoList: 'Hide photo list',
+	/** Label for the zoom-in control. */
+	zoomIn: 'Zoom in',
+	/** Label for the zoom-out control. */
+	zoomOut: 'Zoom out',
+	/** Label for the zoom reset control. */
+	resetZoom: 'Reset zoom',
 };
 
 export type DefaultPhrases = typeof defaultPhrases;

--- a/src/react-bnb-gallery.tsx
+++ b/src/react-bnb-gallery.tsx
@@ -67,7 +67,7 @@ export interface ReactBnbGalleryProps {
  * @param activePhotoPressed - Callback fired when the active photo is pressed
  * @param backgroundColor - Deprecated in 2.x; still supported as compatibility alias for overlay color. Prefer CSS token `--rbg-overlay`
  * @param direction - Navigation direction; deprecated in 2.x — use `activePhotoIndex` with callbacks instead
- * @param enableZoom - Enables zoom controls and pan interactions in the active photo viewport (default: `true`)
+ * @param enableZoom - Enables wheel/pinch zoom and pan interactions in the active photo viewport (default: `true`)
  * @param keyboard - Whether keyboard navigation is enabled (default: `true`)
  * @param leftKeyPressed - Callback fired when the left arrow key is pressed
  * @param light - Enables light mode styling (default: `false`)
@@ -79,10 +79,10 @@ export interface ReactBnbGalleryProps {
  * @param preloadSize - Number of photos to preload ahead of the active photo (default: `5`)
  * @param prevButtonPressed - Callback fired when the previous button is pressed
  * @param rightKeyPressed - Callback fired when the right arrow key is pressed
- * @param maxZoom - Maximum zoom scale applied by controls (default: `3`)
+ * @param maxZoom - Maximum zoom scale applied by gestures (default: `3`)
  * @param show - Whether the gallery modal is visible (default: `false`)
  * @param showThumbnails - Whether the thumbnail strip is shown (default: `true`)
- * @param zoomStep - Zoom increment/decrement per control press (default: `0.25`)
+ * @param zoomStep - Zoom sensitivity step for wheel and pinch interactions (default: `0.25`)
  * @param wrap - Whether navigation wraps around from the last photo to the first (default: `false`)
  * @param zIndex - CSS `z-index` of the modal (default: `1000`)
  */

--- a/src/react-bnb-gallery.tsx
+++ b/src/react-bnb-gallery.tsx
@@ -39,6 +39,7 @@ export interface ReactBnbGalleryProps {
 	 */
 	backgroundColor?: string;
 	direction?: string;
+	enableZoom?: boolean;
 	keyboard?: boolean;
 	leftKeyPressed?: () => void;
 	light?: boolean;
@@ -46,12 +47,14 @@ export interface ReactBnbGalleryProps {
 	onClose?: () => void;
 	opacity?: number;
 	photos?: string | GalleryPhoto | Array<string | GalleryPhoto>;
-	phrases?: GalleryPhrases;
+	phrases?: Partial<GalleryPhrases>;
 	preloadSize?: number;
 	prevButtonPressed?: () => void;
 	rightKeyPressed?: () => void;
+	maxZoom?: number;
 	show?: boolean;
 	showThumbnails?: boolean;
+	zoomStep?: number;
 	wrap?: boolean;
 	zIndex?: number;
 }
@@ -64,6 +67,7 @@ export interface ReactBnbGalleryProps {
  * @param activePhotoPressed - Callback fired when the active photo is pressed
  * @param backgroundColor - Deprecated in 2.x; still supported as compatibility alias for overlay color. Prefer CSS token `--rbg-overlay`
  * @param direction - Navigation direction; deprecated in 2.x — use `activePhotoIndex` with callbacks instead
+ * @param enableZoom - Enables zoom controls and pan interactions in the active photo viewport (default: `true`)
  * @param keyboard - Whether keyboard navigation is enabled (default: `true`)
  * @param leftKeyPressed - Callback fired when the left arrow key is pressed
  * @param light - Enables light mode styling (default: `false`)
@@ -75,8 +79,10 @@ export interface ReactBnbGalleryProps {
  * @param preloadSize - Number of photos to preload ahead of the active photo (default: `5`)
  * @param prevButtonPressed - Callback fired when the previous button is pressed
  * @param rightKeyPressed - Callback fired when the right arrow key is pressed
+ * @param maxZoom - Maximum zoom scale applied by controls (default: `3`)
  * @param show - Whether the gallery modal is visible (default: `false`)
  * @param showThumbnails - Whether the thumbnail strip is shown (default: `true`)
+ * @param zoomStep - Zoom increment/decrement per control press (default: `0.25`)
  * @param wrap - Whether navigation wraps around from the last photo to the first (default: `false`)
  * @param zIndex - CSS `z-index` of the modal (default: `1000`)
  */
@@ -85,6 +91,7 @@ export function ReactBnbGallery({
 	activePhotoPressed,
 	backgroundColor: backgroundColorProp,
 	direction = FORWARDS,
+	enableZoom = true,
 	keyboard = true,
 	leftKeyPressed,
 	light = false,
@@ -92,12 +99,14 @@ export function ReactBnbGallery({
 	onClose,
 	opacity = DEFAULT_OPACITY,
 	photos: photosInput = [],
-	phrases = defaultPhrases,
+	phrases: phrasesProp,
 	preloadSize = 5,
 	prevButtonPressed,
 	rightKeyPressed,
+	maxZoom = 3,
 	show = false,
 	showThumbnails = true,
+	zoomStep = 0.25,
 	wrap = false,
 	zIndex = DEFAULT_Z_INDEX,
 }: ReactBnbGalleryProps) {
@@ -163,6 +172,10 @@ export function ReactBnbGallery({
 	const photos = useMemo(
 		() => normalizePhotos(photosInput || []),
 		[photosInput],
+	);
+	const phrases = useMemo(
+		() => ({ ...defaultPhrases, ...(phrasesProp || {}) }),
+		[phrasesProp],
 	);
 	const [displayedPhotoIndex, setDisplayedPhotoIndex] = useState(() =>
 		normalizeActivePhotoIndex(activePhotoIndex, photos.length),
@@ -277,10 +290,13 @@ export function ReactBnbGallery({
 										activePhotoIndex={activePhotoIndex}
 										activePhotoPressed={activePhotoPressed}
 										direction={direction}
+										enableZoom={enableZoom}
 										nextButtonPressed={nextButtonPressed}
 										prevButtonPressed={prevButtonPressed}
 										showThumbnails={showThumbnails}
 										preloadSize={preloadSize}
+										maxZoom={maxZoom}
+										zoomStep={zoomStep}
 										onActivePhotoIndexChange={setDisplayedPhotoIndex}
 									/>
 								</div>

--- a/tests/components/Gallery.test.js
+++ b/tests/components/Gallery.test.js
@@ -302,29 +302,9 @@ describe('Gallery', () => {
 			expect(activePhotoPressed).toHaveBeenCalledTimes(1);
 		});
 
-		it('renders zoom controls by default', () => {
+		it('does not render zoom controls', () => {
 			const { container } = render(
 				<Gallery photos={photos.slice(0, 2)} showThumbnails={false} />,
-			);
-
-			expect(
-				container.querySelector('button[aria-label="Zoom in"]'),
-			).toBeInTheDocument();
-			expect(
-				container.querySelector('button[aria-label="Zoom out"]'),
-			).toBeInTheDocument();
-			expect(
-				container.querySelector('button[aria-label="Reset zoom"]'),
-			).toBeInTheDocument();
-		});
-
-		it('does not render zoom controls when enableZoom is false', () => {
-			const { container } = render(
-				<Gallery
-					photos={photos.slice(0, 2)}
-					showThumbnails={false}
-					enableZoom={false}
-				/>,
 			);
 
 			expect(
@@ -332,7 +312,30 @@ describe('Gallery', () => {
 			).not.toBeInTheDocument();
 		});
 
-		it('disables swipe navigation while zoomed in', () => {
+		it('enters zoom mode with mouse wheel and disables click navigation', () => {
+			const activePhotoPressed = vi.fn();
+			const { container } = render(
+				<Gallery
+					photos={photos.slice(0, 2)}
+					showThumbnails={false}
+					activePhotoPressed={activePhotoPressed}
+				/>,
+			);
+
+			const photoButton = container.querySelector('.photo-button');
+			const photoImage = container.querySelector('.gallery-photo-image');
+
+			fireEvent.wheel(photoButton, {
+				deltaY: -120,
+				clientX: 120,
+				clientY: 120,
+			});
+			fireEvent.click(photoImage);
+
+			expect(activePhotoPressed).toHaveBeenCalledTimes(0);
+		});
+
+		it('disables swipe navigation while zoomed in from pinch', () => {
 			const nextButtonPressed = vi.fn();
 			const { container } = render(
 				<Gallery
@@ -342,12 +345,20 @@ describe('Gallery', () => {
 				/>,
 			);
 
-			const zoomInButton = container.querySelector(
-				'button[aria-label="Zoom in"]',
-			);
 			const photoButton = container.querySelector('.photo-button');
-
-			fireEvent.click(zoomInButton);
+			fireEvent.touchStart(photoButton, {
+				targetTouches: [
+					{ clientX: 100, clientY: 100 },
+					{ clientX: 180, clientY: 100 },
+				],
+			});
+			fireEvent.touchMove(photoButton, {
+				targetTouches: [
+					{ clientX: 90, clientY: 100 },
+					{ clientX: 210, clientY: 100 },
+				],
+			});
+			fireEvent.touchEnd(photoButton);
 			fireEvent.touchStart(photoButton, {
 				targetTouches: [{ screenX: 200, clientX: 200, clientY: 200 }],
 			});

--- a/tests/components/Gallery.test.js
+++ b/tests/components/Gallery.test.js
@@ -335,6 +335,41 @@ describe('Gallery', () => {
 			expect(activePhotoPressed).toHaveBeenCalledTimes(0);
 		});
 
+		it('resets zoom state when enableZoom is toggled off', () => {
+			const { container, rerender } = render(
+				<Gallery
+					photos={photos.slice(0, 2)}
+					showThumbnails={false}
+					enableZoom
+				/>,
+			);
+
+			const photoButton = container.querySelector('.photo-button');
+			const photoImage = container.querySelector('.gallery-photo-image');
+
+			fireEvent.wheel(photoButton, {
+				deltaY: -120,
+				clientX: 120,
+				clientY: 120,
+			});
+
+			expect(photoImage.style.getPropertyValue('--rbg-zoom-scale')).not.toBe(
+				'1',
+			);
+
+			rerender(
+				<Gallery
+					photos={photos.slice(0, 2)}
+					showThumbnails={false}
+					enableZoom={false}
+				/>,
+			);
+
+			expect(photoImage.style.getPropertyValue('--rbg-zoom-scale')).toBe('1');
+			expect(photoImage.style.getPropertyValue('--rbg-pan-x')).toBe('0px');
+			expect(photoImage.style.getPropertyValue('--rbg-pan-y')).toBe('0px');
+		});
+
 		it('clamps horizontal pan for letterboxed images using rendered media bounds', () => {
 			const { container } = render(
 				<Gallery photos={photos.slice(0, 2)} showThumbnails={false} />,

--- a/tests/components/Gallery.test.js
+++ b/tests/components/Gallery.test.js
@@ -301,5 +301,62 @@ describe('Gallery', () => {
 
 			expect(activePhotoPressed).toHaveBeenCalledTimes(1);
 		});
+
+		it('renders zoom controls by default', () => {
+			const { container } = render(
+				<Gallery photos={photos.slice(0, 2)} showThumbnails={false} />,
+			);
+
+			expect(
+				container.querySelector('button[aria-label="Zoom in"]'),
+			).toBeInTheDocument();
+			expect(
+				container.querySelector('button[aria-label="Zoom out"]'),
+			).toBeInTheDocument();
+			expect(
+				container.querySelector('button[aria-label="Reset zoom"]'),
+			).toBeInTheDocument();
+		});
+
+		it('does not render zoom controls when enableZoom is false', () => {
+			const { container } = render(
+				<Gallery
+					photos={photos.slice(0, 2)}
+					showThumbnails={false}
+					enableZoom={false}
+				/>,
+			);
+
+			expect(
+				container.querySelector('button[aria-label="Zoom in"]'),
+			).not.toBeInTheDocument();
+		});
+
+		it('disables swipe navigation while zoomed in', () => {
+			const nextButtonPressed = vi.fn();
+			const { container } = render(
+				<Gallery
+					photos={photos.slice(0, 2)}
+					showThumbnails={false}
+					nextButtonPressed={nextButtonPressed}
+				/>,
+			);
+
+			const zoomInButton = container.querySelector(
+				'button[aria-label="Zoom in"]',
+			);
+			const photoButton = container.querySelector('.photo-button');
+
+			fireEvent.click(zoomInButton);
+			fireEvent.touchStart(photoButton, {
+				targetTouches: [{ screenX: 200, clientX: 200, clientY: 200 }],
+			});
+			fireEvent.touchMove(photoButton, {
+				targetTouches: [{ screenX: 100, clientX: 100, clientY: 200 }],
+			});
+			fireEvent.touchEnd(photoButton);
+
+			expect(nextButtonPressed).toHaveBeenCalledTimes(0);
+		});
 	});
 });

--- a/tests/components/Gallery.test.js
+++ b/tests/components/Gallery.test.js
@@ -335,6 +335,43 @@ describe('Gallery', () => {
 			expect(activePhotoPressed).toHaveBeenCalledTimes(0);
 		});
 
+		it('clamps horizontal pan for letterboxed images using rendered media bounds', () => {
+			const { container } = render(
+				<Gallery photos={photos.slice(0, 2)} showThumbnails={false} />,
+			);
+
+			const photoButton = container.querySelector('.photo-button');
+			const photoImage = container.querySelector('.gallery-photo-image');
+
+			Object.defineProperty(photoButton, 'clientWidth', {
+				value: 1000,
+				configurable: true,
+			});
+			Object.defineProperty(photoButton, 'clientHeight', {
+				value: 500,
+				configurable: true,
+			});
+			Object.defineProperty(photoImage, 'naturalWidth', {
+				value: 600,
+				configurable: true,
+			});
+			Object.defineProperty(photoImage, 'naturalHeight', {
+				value: 1200,
+				configurable: true,
+			});
+
+			fireEvent.wheel(photoButton, {
+				deltaY: -120,
+				clientX: 200,
+				clientY: 200,
+			});
+			fireEvent.mouseDown(photoButton, { clientX: 100, clientY: 100 });
+			fireEvent.mouseMove(photoButton, { clientX: 700, clientY: 100 });
+			fireEvent.mouseUp(photoButton);
+
+			expect(photoImage.style.getPropertyValue('--rbg-pan-x')).toBe('0px');
+		});
+
 		it('disables swipe navigation while zoomed in from pinch', () => {
 			const nextButtonPressed = vi.fn();
 			const { container } = render(

--- a/tests/components/react-bnb-gallery.test.js
+++ b/tests/components/react-bnb-gallery.test.js
@@ -206,5 +206,19 @@ describe('ReactBnbGallery', () => {
 				expect.stringContaining('Deprecation: `backgroundColor` is deprecated'),
 			);
 		});
+
+		it('supports partial phrase overrides and keeps default zoom labels', () => {
+			render(
+				<ReactBnbGallery
+					photos={photos.slice(0, 2)}
+					show
+					phrases={{ noPhotosProvided: 'Sin fotos' }}
+				/>,
+			);
+
+			expect(
+				document.body.querySelector('button[aria-label="Zoom in"]'),
+			).toBeInTheDocument();
+		});
 	});
 });

--- a/tests/components/react-bnb-gallery.test.js
+++ b/tests/components/react-bnb-gallery.test.js
@@ -207,7 +207,7 @@ describe('ReactBnbGallery', () => {
 			);
 		});
 
-		it('supports partial phrase overrides and keeps default zoom labels', () => {
+		it('supports partial phrase overrides and keeps default caption labels', () => {
 			render(
 				<ReactBnbGallery
 					photos={photos.slice(0, 2)}
@@ -216,9 +216,9 @@ describe('ReactBnbGallery', () => {
 				/>,
 			);
 
-			expect(
-				document.body.querySelector('button[aria-label="Zoom in"]'),
-			).toBeInTheDocument();
+			expect(document.body).toHaveTextContent(
+				/Hide photo list|Show photo list/,
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Simplify zoom UX to gesture-only behavior with no on-screen zoom controls.
- Desktop: mouse wheel zoom + click/drag pan while zoomed.
- Mobile: pinch-to-zoom + pan while zoomed.
- Disable click-to-next and swipe navigation while in zoom mode.
- Reset zoom state when active photo changes and when `enableZoom` is toggled off.
- Clamp pan bounds using rendered media dimensions (not container dimensions), preventing empty background exposure on letterboxed images.
- Remove unused zoom phrase labels from default phrases.

## Scope

- In scope:
  - Active-photo zoom/pan interaction model.
  - Gesture handling (wheel, pinch, drag) and zoom-mode behavior rules.
  - Pan clamping correctness for letterboxed media.
  - Regression tests for zoom disable/reset and clamping behavior.
- Out of scope:
  - New visible zoom UI controls.

## Linked Plan

- Plan file: `MODERNIZATION_PLAN_v3.md`
- Task: `V3_FEATURE_001_ZOOM_PAN`

## Validation

- [x] Lint passed
- [x] Tests passed
- [x] Build passed
- [x] Docs build passed
- Commands run:
  - `pnpm lint`
  - `pnpm test`
  - `pnpm build`
  - `pnpm docs:build`

## Compatibility

- Breaking changes: no
- Notes:
  - Zoom controls UI removed from behavior.
  - `defaultPhrases` no longer includes unused zoom control labels.

## Security

- Risk level: low
- New dependencies introduced: none

## Follow-ups

- Add/refresh docs examples for gesture-based zoom behavior.
