### PR TITLE
feat(v3): add caption action render slot

### DIFF
--- a/.changeset/eight-rules-beam.md
+++ b/.changeset/eight-rules-beam.md
@@ -10,4 +10,4 @@ This introduces opt-in/controlled zoom behavior through new props:
 - `maxZoom` (default `3`)
 - `zoomStep` (default `0.25`)
 
-It also adds built-in zoom controls (`zoom in`, `zoom out`, `reset zoom`) with localizable phrases and prevents swipe/click-next interactions while zoom is active.
+Zoom is gesture-only (no visible zoom controls): desktop wheel/trackpad zoom, mobile pinch-to-zoom, and pan while zoomed. Swipe/click-next interactions are disabled while zoom mode is active, and pan bounds are clamped using rendered media dimensions.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -6,6 +6,7 @@
     "@react-bnb-gallery/docs": "0.1.0"
   },
   "changesets": [
+    "eight-rules-beam",
     "mean-news-act",
     "tall-forks-jump"
   ]

--- a/.changeset/tidy-guests-knock.md
+++ b/.changeset/tidy-guests-knock.md
@@ -1,0 +1,7 @@
+---
+"react-bnb-gallery": minor
+---
+
+Add a new `renderCaptionActions` render prop to inject custom controls in the caption action area.
+
+The slot renders next to the existing photo-list toggle and receives context (`current`, `currentPhoto`, `photos`, `showThumbnails`) so consumers can build action buttons (for example download/share actions) without forking the gallery layout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 3.0.0-next.2
+
+### Minor Changes
+
+- 10717b8: Add active-photo zoom and pan support in the gallery viewport.
+
+  This introduces opt-in/controlled zoom behavior through new props:
+
+  - `enableZoom` (default `true`)
+  - `maxZoom` (default `3`)
+  - `zoomStep` (default `0.25`)
+
+  Zoom is gesture-only (no visible zoom controls): desktop wheel/trackpad zoom, mobile pinch-to-zoom, and pan while zoomed. Swipe/click-next interactions are disabled while zoom mode is active, and pan bounds are clamped using rendered media dimensions.
+
 ## 3.0.0-next.1
 
 ### Patch Changes

--- a/docs/app/(docs)/docs/options/page.tsx
+++ b/docs/app/(docs)/docs/options/page.tsx
@@ -13,7 +13,12 @@ const galleryProps = [
 		default: "'deprecated (compat alias)'",
 		deprecated: true,
 	},
-	{ prop: 'direction', type: 'string', default: "'forwards'", deprecated: true },
+	{
+		prop: 'direction',
+		type: 'string',
+		default: "'forwards'",
+		deprecated: true,
+	},
 	{ prop: 'keyboard', type: 'boolean', default: 'true' },
 	{ prop: 'leftKeyPressed', type: '() => void', default: 'undefined' },
 	{ prop: 'light', type: 'boolean', default: 'false' },
@@ -24,6 +29,11 @@ const galleryProps = [
 	{ prop: 'phrases', type: 'GalleryPhrases', default: '{...}' },
 	{ prop: 'preloadSize', type: 'number', default: '5' },
 	{ prop: 'prevButtonPressed', type: '() => void', default: 'undefined' },
+	{
+		prop: 'renderCaptionActions',
+		type: '(context) => ReactNode',
+		default: 'undefined',
+	},
 	{ prop: 'rightKeyPressed', type: '() => void', default: 'undefined' },
 	{ prop: 'show', type: 'boolean', default: 'false' },
 	{ prop: 'showThumbnails', type: 'boolean', default: 'true' },
@@ -198,8 +208,8 @@ export default function OptionsPage() {
 						<PropDetail name="backgroundColor" deprecated>
 							<p>
 								This prop is deprecated in <code>2.x</code>, still works as a
-								backward-compatible alias for overlay color, and will be
-								removed in the next major version. Prefer the CSS token{' '}
+								backward-compatible alias for overlay color, and will be removed
+								in the next major version. Prefer the CSS token{' '}
 								<code>--rbg-overlay</code> instead.
 							</p>
 							<CodeBlock
@@ -219,9 +229,9 @@ export default function OptionsPage() {
 
 						<PropDetail name="direction" deprecated>
 							<p>
-								Controls the animation direction when navigating between
-								photos. This prop is deprecated and will be removed in the
-								next major version — avoid using it in new code.
+								Controls the animation direction when navigating between photos.
+								This prop is deprecated and will be removed in the next major
+								version — avoid using it in new code.
 							</p>
 						</PropDetail>
 
@@ -276,9 +286,9 @@ export default function OptionsPage() {
 
 						<PropDetail name="light">
 							<p>
-								Enables a light color scheme for the gallery UI. By default
-								the gallery uses a dark theme. Set to <code>true</code> to
-								switch to a light background with dark controls.
+								Enables a light color scheme for the gallery UI. By default the
+								gallery uses a dark theme. Set to <code>true</code> to switch to
+								a light background with dark controls.
 							</p>
 							<CodeBlock
 								__raw__={`<ReactBnbGallery
@@ -560,6 +570,39 @@ export default function OptionsPage() {
 							</CodeBlock>
 						</PropDetail>
 
+						<PropDetail name="renderCaptionActions">
+							<p>
+								Render prop for injecting custom controls in the caption action
+								area next to the photo-list toggle button. Useful for adding
+								actions like download, share, or open-original.
+							</p>
+							<CodeBlock
+								__raw__={`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  renderCaptionActions={({ currentPhoto }) => (
+    <button type="button" onClick={() => window.open(currentPhoto?.photo)}>
+      Open original
+    </button>
+  )}
+  onClose={() => setOpen(false)}
+/>`}
+							>
+								<pre>
+									<code>{`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  renderCaptionActions={({ currentPhoto }) => (
+    <button type="button" onClick={() => window.open(currentPhoto?.photo)}>
+      Open original
+    </button>
+  )}
+  onClose={() => setOpen(false)}
+/>`}</code>
+								</pre>
+							</CodeBlock>
+						</PropDetail>
+
 						<PropDetail name="show">
 							<p>
 								Controls the visibility of the gallery modal. Set to{' '}
@@ -792,8 +835,8 @@ export default function OptionsPage() {
 
 						<PropDetail name="thumbnailAlt">
 							<p>
-								Accessible text for the thumbnail image. When omitted, it
-								falls back to <code>alt</code>, then <code>caption</code>.
+								Accessible text for the thumbnail image. When omitted, it falls
+								back to <code>alt</code>, then <code>caption</code>.
 							</p>
 							<CodeBlock
 								__raw__={`photos={[

--- a/docs/release/V3_FEATURE_001_ZOOM_PAN.md
+++ b/docs/release/V3_FEATURE_001_ZOOM_PAN.md
@@ -12,14 +12,19 @@ Last updated: 2026-03-06
 
 ## Problem
 
-Users need closer inspection of image details without leaving the gallery. Current behavior centers and scales photos but does not provide in-view zoom/pan controls.
+Users need closer inspection of image details without leaving the gallery. Current behavior centers and scales photos but does not provide direct gesture-based zoom/pan interaction.
 
 ## Proposal
 
-1. Add zoom in/out capability on the active photo view.
-2. Allow panning when zoom scale is above 1x.
-3. Preserve current next/prev controls and close behavior.
-4. Keep default behavior unchanged unless zoom is activated.
+1. Add gesture-based zoom on the active photo view:
+   - Desktop: mouse wheel/trackpad zoom.
+   - Mobile: pinch-to-zoom.
+2. Allow panning when zoom scale is above 1x:
+   - Desktop: click-and-drag.
+   - Mobile: touch drag.
+3. Preserve existing next/prev controls and close behavior outside zoom mode.
+4. Disable click-next and swipe navigation while zoom mode is active.
+5. Keep default behavior unchanged unless zoom is activated.
 
 ## API Surface (Draft)
 
@@ -27,31 +32,32 @@ Users need closer inspection of image details without leaving the gallery. Curre
    - `enableZoom?: boolean` (default `true`)
    - `maxZoom?: number` (default `3`)
    - `zoomStep?: number` (default `0.25`)
-2. New phrases for controls:
-   - `zoomIn`, `zoomOut`, `resetZoom`
-3. No removals in this feature.
+2. Phrase cleanup:
+   - Remove unused zoom-control labels from `defaultPhrases` (`zoomIn`, `zoomOut`, `resetZoom`) because zoom UI controls are not rendered.
+3. No required migration for existing zoom props.
 
 ## Accessibility
 
-1. Zoom controls must be keyboard reachable and labeled.
-2. `Esc` behavior stays close-first unless focused on explicit zoom control action.
+1. `Esc` behavior remains close-first.
+2. Zoom mode must not trap focus or break keyboard navigation semantics.
 3. Respect reduced-motion preference for zoom transitions.
 
 ## Testing Plan
 
 1. Add component tests for zoom state transitions.
-2. Add regression tests for existing keyboard navigation while zoom is enabled/disabled.
+2. Add regression tests for existing keyboard and swipe navigation while zoom is enabled/disabled.
 3. Manual QA on mouse, trackpad, and touch interactions.
+4. Add regression test for pan clamping against rendered media bounds (letterboxed images).
 
 ## Docs Plan
 
 1. Add option docs for zoom props.
 2. Add a docs example showing zoom/pan interaction.
-3. Update migration docs only if any defaults become behaviorally breaking.
+3. Update feature notes to document gesture-only zoom behavior.
 
 ## Acceptance Criteria
 
-1. Zoom controls function with keyboard and pointer input.
-2. Panning is bounded and does not break layout.
+1. Gesture zoom functions on desktop and mobile without dedicated zoom buttons.
+2. Panning is bounded to rendered media overflow and does not expose empty background on letterboxed media.
 3. Existing gallery tests remain green with no behavior regressions.
 4. `pnpm lint`, `pnpm test`, `pnpm build`, and `pnpm docs:build` all pass.

--- a/docs/release/V3_FEATURE_002_CUSTOM_RENDER_SLOTS.md
+++ b/docs/release/V3_FEATURE_002_CUSTOM_RENDER_SLOTS.md
@@ -1,0 +1,53 @@
+# V3 Feature 002: Custom Render Slots
+
+Last updated: 2026-03-06
+
+## Metadata
+
+1. Feature ID: `v3-feature-002`
+2. Branch: `feat/v3-custom-render-slots`
+3. Owner: TBD
+4. Target prerelease: `3.0.0-next.3`
+5. Changeset type: `minor`
+
+## Problem
+
+Consumers need to add custom action buttons near the thumbnail toggle area (for example download/share/open-original) without forking the gallery layout.
+
+## Proposal
+
+1. Add a render prop slot for caption actions.
+2. Render custom actions in the caption-right area, next to the existing photo-list toggle.
+3. Keep existing caption/toggle behavior intact by default.
+
+## API Surface
+
+1. New prop:
+   - `renderCaptionActions?: (context) => ReactNode`
+2. New exported types:
+   - `GalleryCaptionActionsContext`
+   - `GalleryRenderCaptionActions`
+3. Backward compatibility:
+   - No behavior changes when `renderCaptionActions` is omitted.
+
+## Accessibility
+
+1. Custom action focus order follows normal DOM flow in caption-right.
+2. Existing toggle button semantics remain unchanged.
+3. No changes to dialog or keyboard navigation contracts.
+
+## Testing Plan
+
+1. Caption component tests for:
+   - custom action rendering with/without multiple photos
+   - coexistence with toggle controls
+2. ReactBnbGallery integration test for prop wiring/context.
+
+## Docs Plan
+
+1. Add option docs for `renderCaptionActions`.
+2. Add usage example with custom buttons in caption-right area.
+
+## Release Notes Draft
+
+Add a new render slot (`renderCaptionActions`) to inject custom actions in the caption area next to the photo-list toggle, without changing default gallery behavior.

--- a/docs/release/V3_ROADMAP.md
+++ b/docs/release/V3_ROADMAP.md
@@ -1,6 +1,6 @@
 # React BnB Gallery v3 Roadmap
 
-Last updated: 2026-02-26
+Last updated: 2026-03-06
 
 This document tracks items intentionally deferred to the next major version (`v3`).
 
@@ -9,8 +9,8 @@ This document tracks items intentionally deferred to the next major version (`v3
 | GitHub Issue | Topic | Status | Notes |
 | --- | --- | --- | --- |
 | [#15](https://github.com/pedropalau/react-bnb-gallery/issues/15) | Theming support | Planned | Track a first-class theming API (tokens/variables + documented customization patterns). |
-| [#21](https://github.com/pedropalau/react-bnb-gallery/issues/21) | Zoomable images | Planned | Define a zoom/pan-capable media API without breaking current navigation interactions. |
-| [#39](https://github.com/pedropalau/react-bnb-gallery/issues/39) | Pinch-to-zoom triggers next image on mobile | Planned | Track with zoom/gesture redesign in v3; related to #21 and depends on the same interaction model changes. |
+| [#21](https://github.com/pedropalau/react-bnb-gallery/issues/21) | Zoomable images | Completed | Delivered in `feat/v3-zoom-pan`: gesture-based zoom (wheel/pinch), pan while zoomed, zoom-mode navigation safeguards. |
+| [#39](https://github.com/pedropalau/react-bnb-gallery/issues/39) | Pinch-to-zoom triggers next image on mobile | Completed | Resolved by v3 zoom redesign: pinch gesture no longer triggers next/prev navigation while zoom mode is active. |
 | [#51](https://github.com/pedropalau/react-bnb-gallery/issues/51) | Custom buttons after thumbnails | Planned | Add extensibility hooks (for example, slots/render props) for custom actions in the thumbnail area. |
 
 ## Scope Notes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bnb-gallery",
-  "version": "3.0.0-next.1",
+  "version": "3.0.0-next.2",
   "description": "Accessible React lightbox and photo gallery component inspired by Airbnb’s image gallery.",
   "author": "Pedro Palau <palauisaac@gmail.com>",
   "homepage": "https://bnb-gallery.vercel.app",

--- a/src/components/caption.tsx
+++ b/src/components/caption.tsx
@@ -2,7 +2,11 @@ import clsx from 'clsx';
 import type { MouseEvent } from 'react';
 import { memo, useEffect, useRef, useState } from 'react';
 import { defaultPhrases } from '../default-phrases';
-import type { GalleryPhoto, GalleryPhrases } from '../types/gallery';
+import type {
+	GalleryPhoto,
+	GalleryPhrases,
+	GalleryRenderCaptionActions,
+} from '../types/gallery';
 import {
 	calculateThumbnailsContainerDimension,
 	calculateThumbnailsLeftScroll,
@@ -18,6 +22,7 @@ interface CaptionProps {
 	onPress?: (index: number) => void;
 	photos?: GalleryPhoto[];
 	phrases?: GalleryPhrases;
+	renderCaptionActions?: GalleryRenderCaptionActions;
 	showThumbnails?: boolean;
 }
 
@@ -29,6 +34,7 @@ function Caption({
 	onPress,
 	photos = [],
 	phrases = defaultPhrases,
+	renderCaptionActions,
 	showThumbnails: showThumbnailsProp = true,
 }: CaptionProps) {
 	const [showThumbnails, setShowThumbnails] = useState(showThumbnailsProp);
@@ -75,6 +81,13 @@ function Caption({
 		photos.length,
 	);
 	const hasMoreThanOnePhoto = photos.length > 1;
+	const customActions = renderCaptionActions?.({
+		current,
+		currentPhoto,
+		photos,
+		showThumbnails,
+	});
+	const hasCaptionRightContent = hasMoreThanOnePhoto || customActions != null;
 
 	return (
 		<figcaption className={className}>
@@ -89,13 +102,22 @@ function Caption({
 								<p className="photo-subcaption">{currentPhoto.subcaption}</p>
 							)}
 						</div>
-						{hasMoreThanOnePhoto && (
+						{hasCaptionRightContent && (
 							<div className="caption-right">
-								<TogglePhotoList
-									phrases={phrases}
-									isOpened={showThumbnails}
-									onPress={toggleThumbnails}
-								/>
+								<div className="gallery-caption-actions">
+									{hasMoreThanOnePhoto && (
+										<TogglePhotoList
+											phrases={phrases}
+											isOpened={showThumbnails}
+											onPress={toggleThumbnails}
+										/>
+									)}
+									{customActions != null && (
+										<div className="gallery-caption-custom-actions">
+											{customActions}
+										</div>
+									)}
+								</div>
 							</div>
 						)}
 					</div>

--- a/src/components/gallery.tsx
+++ b/src/components/gallery.tsx
@@ -16,6 +16,7 @@ import type {
 	GalleryController,
 	GalleryPhoto,
 	GalleryPhrases,
+	GalleryRenderCaptionActions,
 } from '../types/gallery';
 import { Caption } from './caption';
 import { NextButton } from './next-button';
@@ -38,6 +39,7 @@ interface GalleryProps {
 	photos?: GalleryPhoto[];
 	preloadSize?: number;
 	prevButtonPressed?: () => void;
+	renderCaptionActions?: GalleryRenderCaptionActions;
 	showThumbnails?: boolean;
 	zoomStep?: number;
 	wrap?: boolean;
@@ -166,6 +168,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 		photos = EMPTY_PHOTOS,
 		preloadSize = 5,
 		prevButtonPressed,
+		renderCaptionActions,
 		showThumbnails = true,
 		zoomStep = 0.25,
 		wrap = false,
@@ -868,6 +871,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 					current={state.activePhotoIndex}
 					photos={photos}
 					onPress={onThumbnailPress}
+					renderCaptionActions={renderCaptionActions}
 				/>
 			)}
 		</div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -567,6 +567,19 @@
 		display: table-cell;
 	}
 
+	.gallery-caption-actions {
+		display: inline-flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: 0.75rem;
+	}
+
+	.gallery-caption-custom-actions {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
 	.gallery-figcaption--info .photo-caption,
 	.gallery-figcaption--info .photo-subcaption {
 		margin: 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,9 @@ export { ReactBnbGallery, Gallery };
 export type { ReactBnbGalleryProps } from './react-bnb-gallery';
 
 export type {
+	GalleryCaptionActionsContext,
 	GalleryController,
 	GalleryPhoto,
 	GalleryPhrases,
+	GalleryRenderCaptionActions,
 } from './types/gallery';

--- a/src/react-bnb-gallery.tsx
+++ b/src/react-bnb-gallery.tsx
@@ -18,6 +18,7 @@ import type {
 	GalleryController,
 	GalleryPhoto,
 	GalleryPhrases,
+	GalleryRenderCaptionActions,
 } from './types/gallery';
 import { normalizePhotos } from './utils/normalize-photos';
 
@@ -50,6 +51,7 @@ export interface ReactBnbGalleryProps {
 	phrases?: Partial<GalleryPhrases>;
 	preloadSize?: number;
 	prevButtonPressed?: () => void;
+	renderCaptionActions?: GalleryRenderCaptionActions;
 	rightKeyPressed?: () => void;
 	maxZoom?: number;
 	show?: boolean;
@@ -78,6 +80,7 @@ export interface ReactBnbGalleryProps {
  * @param phrases - Localization strings for UI labels
  * @param preloadSize - Number of photos to preload ahead of the active photo (default: `5`)
  * @param prevButtonPressed - Callback fired when the previous button is pressed
+ * @param renderCaptionActions - Render prop for injecting custom controls in the caption action area
  * @param rightKeyPressed - Callback fired when the right arrow key is pressed
  * @param maxZoom - Maximum zoom scale applied by gestures (default: `3`)
  * @param show - Whether the gallery modal is visible (default: `false`)
@@ -102,6 +105,7 @@ export function ReactBnbGallery({
 	phrases: phrasesProp,
 	preloadSize = 5,
 	prevButtonPressed,
+	renderCaptionActions,
 	rightKeyPressed,
 	maxZoom = 3,
 	show = false,
@@ -293,6 +297,7 @@ export function ReactBnbGallery({
 										enableZoom={enableZoom}
 										nextButtonPressed={nextButtonPressed}
 										prevButtonPressed={prevButtonPressed}
+										renderCaptionActions={renderCaptionActions}
 										showThumbnails={showThumbnails}
 										preloadSize={preloadSize}
 										maxZoom={maxZoom}

--- a/src/types/gallery.ts
+++ b/src/types/gallery.ts
@@ -23,6 +23,23 @@ export interface GalleryPhoto {
 	[key: string]: unknown;
 }
 
+/** Context provided to custom caption action renderers. */
+export interface GalleryCaptionActionsContext {
+	/** Current active photo index. */
+	current: number;
+	/** Currently active photo object, when available. */
+	currentPhoto?: GalleryPhoto;
+	/** Full normalized photo list. */
+	photos: GalleryPhoto[];
+	/** Whether the thumbnail strip is currently visible. */
+	showThumbnails: boolean;
+}
+
+/** Render prop for injecting custom controls in the caption action area. */
+export type GalleryRenderCaptionActions = (
+	context: GalleryCaptionActionsContext,
+) => ReactNode;
+
 /** Exposes navigation controls for programmatic gallery control. */
 export interface GalleryController {
 	/** Navigate to the previous photo. */

--- a/tests/components/Caption.test.js
+++ b/tests/components/Caption.test.js
@@ -108,5 +108,42 @@ describe('Caption', () => {
 			).toBeInTheDocument();
 			expect(screen.getByText('Photo by')).toBeInTheDocument();
 		});
+
+		it('renders custom caption actions next to the thumbnail toggle', () => {
+			render(
+				<Caption
+					current={0}
+					photos={photos.slice(0, 2)}
+					showThumbnails
+					renderCaptionActions={({ current }) => (
+						<button type="button">Action {current + 1}</button>
+					)}
+				/>,
+			);
+
+			expect(
+				screen.getByRole('button', { name: /hide photo list/i }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole('button', { name: 'Action 1' }),
+			).toBeInTheDocument();
+		});
+
+		it('renders custom caption actions even with a single photo', () => {
+			render(
+				<Caption
+					current={0}
+					photos={photos.slice(0, 1)}
+					renderCaptionActions={() => <button type="button">Download</button>}
+				/>,
+			);
+
+			expect(
+				screen.getByRole('button', { name: 'Download' }),
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole('button', { name: /photo list/i }),
+			).not.toBeInTheDocument();
+		});
 	});
 });

--- a/tests/components/Gallery.test.js
+++ b/tests/components/Gallery.test.js
@@ -302,6 +302,20 @@ describe('Gallery', () => {
 			expect(activePhotoPressed).toHaveBeenCalledTimes(1);
 		});
 
+		it('renders custom caption actions from renderCaptionActions', () => {
+			const { container } = render(
+				<Gallery
+					photos={photos.slice(0, 2)}
+					showThumbnails
+					renderCaptionActions={({ current }) => (
+						<button type="button">Action {current + 1}</button>
+					)}
+				/>,
+			);
+
+			expect(container).toHaveTextContent('Action 1');
+		});
+
 		it('does not render zoom controls', () => {
 			const { container } = render(
 				<Gallery photos={photos.slice(0, 2)} showThumbnails={false} />,

--- a/tests/components/react-bnb-gallery.test.js
+++ b/tests/components/react-bnb-gallery.test.js
@@ -220,5 +220,27 @@ describe('ReactBnbGallery', () => {
 				/Hide photo list|Show photo list/,
 			);
 		});
+
+		it('renders custom caption actions via renderCaptionActions', () => {
+			const renderCaptionActions = vi.fn(({ current }) => (
+				<button type="button">Custom {current + 1}</button>
+			));
+
+			render(
+				<ReactBnbGallery
+					photos={photos.slice(0, 2)}
+					show
+					renderCaptionActions={renderCaptionActions}
+				/>,
+			);
+
+			expect(renderCaptionActions).toHaveBeenCalledWith(
+				expect.objectContaining({
+					current: 0,
+					showThumbnails: true,
+				}),
+			);
+			expect(document.body).toHaveTextContent('Custom 1');
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- Add a new `renderCaptionActions` render prop for injecting custom controls in the caption action area.
- Wire the slot through `ReactBnbGallery -> Gallery -> Caption`.
- Add exported types: `GalleryCaptionActionsContext` and `GalleryRenderCaptionActions`.
- Preserve default behavior when slot is not provided.
- Add tests for Caption, Gallery, and ReactBnbGallery slot rendering/context.
- Update docs options page and add feature spec for V3 feature 002.
- Include minor changeset for release.

## Validation

- [x] `pnpm lint:biome`
- [x] `pnpm test tests/components/Caption.test.js tests/components/Gallery.test.js tests/components/react-bnb-gallery.test.js`
- [x] `pnpm typecheck`
- [x] `pnpm docs:build`

## Notes

- Existing behavior remains unchanged unless `renderCaptionActions` is passed.
