### PR TITLE
feat(v3): theming customization with components/classNames/styles

### DIFF
--- a/.changeset/soft-oranges-listen.md
+++ b/.changeset/soft-oranges-listen.md
@@ -1,0 +1,10 @@
+---
+"react-bnb-gallery": minor
+---
+
+Improve gallery customization with a new theming layer and component-slot API.
+
+- Add `components` prop to replace internal UI slots (`CloseButton`, `PrevButton`, `NextButton`, `Photo`, `Caption`, `Thumbnail`, `TogglePhotoList`).
+- Add `classNames` and `styles` props for lightweight styling overrides without replacing internal rendering.
+- Export new customization types (`GalleryComponents`, `GalleryClassNames`, `GalleryStyles`, and slot prop types) from the package entrypoint.
+- Update docs with a dedicated "Theming & Component Slots" section and usage examples.

--- a/docs/app/(docs)/docs/options/page.tsx
+++ b/docs/app/(docs)/docs/options/page.tsx
@@ -34,6 +34,11 @@ const galleryProps = [
 		type: '(context) => ReactNode',
 		default: 'undefined',
 	},
+	{
+		prop: 'components',
+		type: 'GalleryComponents',
+		default: 'undefined',
+	},
 	{ prop: 'rightKeyPressed', type: '() => void', default: 'undefined' },
 	{ prop: 'show', type: 'boolean', default: 'false' },
 	{ prop: 'showThumbnails', type: 'boolean', default: 'true' },
@@ -597,6 +602,54 @@ export default function OptionsPage() {
       Open original
     </button>
   )}
+  onClose={() => setOpen(false)}
+/>`}</code>
+								</pre>
+							</CodeBlock>
+						</PropDetail>
+
+						<PropDetail name="components">
+							<p>
+								Overrides internal UI slots (close button, controls, photo,
+								caption, thumbnails) with your own React components. This is
+								useful when you need deep design-system integration without
+								forking the library.
+							</p>
+							<CodeBlock
+								__raw__={`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  components={{
+    CloseButton: ({ onPress }) => (
+      <button type="button" className="my-close" onClick={onPress}>
+        Close
+      </button>
+    ),
+    NextButton: ({ onPress, disabled }) => (
+      <button type="button" disabled={disabled} onClick={onPress}>
+        Next
+      </button>
+    ),
+  }}
+  onClose={() => setOpen(false)}
+/>`}
+							>
+								<pre>
+									<code>{`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  components={{
+    CloseButton: ({ onPress }) => (
+      <button type="button" className="my-close" onClick={onPress}>
+        Close
+      </button>
+    ),
+    NextButton: ({ onPress, disabled }) => (
+      <button type="button" disabled={disabled} onClick={onPress}>
+        Next
+      </button>
+    ),
+  }}
   onClose={() => setOpen(false)}
 />`}</code>
 								</pre>

--- a/docs/app/(docs)/docs/options/page.tsx
+++ b/docs/app/(docs)/docs/options/page.tsx
@@ -39,6 +39,8 @@ const galleryProps = [
 		type: 'GalleryComponents',
 		default: 'undefined',
 	},
+	{ prop: 'classNames', type: 'GalleryClassNames', default: 'undefined' },
+	{ prop: 'styles', type: 'GalleryStyles', default: 'undefined' },
 	{ prop: 'rightKeyPressed', type: '() => void', default: 'undefined' },
 	{ prop: 'show', type: 'boolean', default: 'false' },
 	{ prop: 'showThumbnails', type: 'boolean', default: 'true' },
@@ -656,6 +658,76 @@ export default function OptionsPage() {
 							</CodeBlock>
 						</PropDetail>
 
+						<PropDetail name="classNames">
+							<p>
+								Applies class names to built-in UI slots without replacing
+								components. Use this for lightweight theming with utility-first
+								or design-system classes.
+							</p>
+							<CodeBlock
+								__raw__={`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  classNames={{
+    modal: 'rounded-2xl',
+    overlay: 'backdrop-blur-sm',
+    photoButton: 'ring-2 ring-white/30',
+    caption: 'bg-black/70',
+    thumbnailButton: 'rounded-md border border-white/30',
+  }}
+  onClose={() => setOpen(false)}
+/>`}
+							>
+								<pre>
+									<code>{`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  classNames={{
+    modal: 'rounded-2xl',
+    overlay: 'backdrop-blur-sm',
+    photoButton: 'ring-2 ring-white/30',
+    caption: 'bg-black/70',
+    thumbnailButton: 'rounded-md border border-white/30',
+  }}
+  onClose={() => setOpen(false)}
+/>`}</code>
+								</pre>
+							</CodeBlock>
+						</PropDetail>
+
+						<PropDetail name="styles">
+							<p>
+								Applies inline styles to the same slots available in{' '}
+								<code>classNames</code>. Useful for dynamic runtime styling or
+								theme-token values from JavaScript.
+							</p>
+							<CodeBlock
+								__raw__={`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  styles={{
+    overlay: { backgroundColor: 'rgba(8, 10, 20, 0.9)' },
+    photoCounter: { letterSpacing: '0.12em' },
+    caption: { borderTop: '1px solid rgba(255,255,255,0.2)' },
+  }}
+  onClose={() => setOpen(false)}
+/>`}
+							>
+								<pre>
+									<code>{`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  styles={{
+    overlay: { backgroundColor: 'rgba(8, 10, 20, 0.9)' },
+    photoCounter: { letterSpacing: '0.12em' },
+    caption: { borderTop: '1px solid rgba(255,255,255,0.2)' },
+  }}
+  onClose={() => setOpen(false)}
+/>`}</code>
+								</pre>
+							</CodeBlock>
+						</PropDetail>
+
 						<PropDetail name="show">
 							<p>
 								Controls the visibility of the gallery modal. Set to{' '}
@@ -764,6 +836,62 @@ export default function OptionsPage() {
 							</CodeBlock>
 						</PropDetail>
 					</div>
+				</div>
+
+				<div className="flex flex-col gap-4 rounded-lg border border-border bg-muted/30 p-6">
+					<h2 className="text-lg font-semibold tracking-tight">
+						Theming &amp; Component Slots
+					</h2>
+					<p className="text-sm text-muted-foreground">
+						Use <code>classNames</code> and <code>styles</code> for fast visual
+						customization, and use <code>components</code> when you need to
+						replace internal rendering with your own design-system components.
+					</p>
+					<CodeBlock
+						__raw__={`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  classNames={{
+    overlay: 'bg-slate-950/90 backdrop-blur-md',
+    caption: 'bg-slate-950/80',
+    togglePhotoList: 'text-sky-300 hover:text-sky-200',
+  }}
+  styles={{
+    photoCounter: { fontVariantNumeric: 'tabular-nums' },
+  }}
+  components={{
+    CloseButton: ({ onPress, className }) => (
+      <button type="button" className={\`btn btn-ghost \${className ?? ''}\`} onClick={onPress}>
+        Dismiss
+      </button>
+    ),
+  }}
+  onClose={() => setOpen(false)}
+/>`}
+					>
+						<pre>
+							<code>{`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  classNames={{
+    overlay: 'bg-slate-950/90 backdrop-blur-md',
+    caption: 'bg-slate-950/80',
+    togglePhotoList: 'text-sky-300 hover:text-sky-200',
+  }}
+  styles={{
+    photoCounter: { fontVariantNumeric: 'tabular-nums' },
+  }}
+  components={{
+    CloseButton: ({ onPress, className }) => (
+      <button type="button" className={\`btn btn-ghost \${className ?? ''}\`} onClick={onPress}>
+        Dismiss
+      </button>
+    ),
+  }}
+  onClose={() => setOpen(false)}
+/>`}</code>
+						</pre>
+					</CodeBlock>
 				</div>
 
 				{/* Photo props */}

--- a/docs/app/(docs)/docs/theming/page.tsx
+++ b/docs/app/(docs)/docs/theming/page.tsx
@@ -1,0 +1,137 @@
+import Link from 'next/link';
+import { CodeBlock } from '@/components/code-block';
+import { DocsPage, DocsPageHeading2, DocsPageParagraph } from '@/components/docs-page';
+import { createPageMetadata } from '@/lib/metadata';
+
+export const metadata = createPageMetadata('Theming');
+
+export default function ThemingPage() {
+	return (
+		<DocsPage
+			title="Theming"
+			description="Customize react-bnb-gallery with class names, inline styles, or full component slot overrides."
+			path="theming"
+		>
+			<DocsPageParagraph>
+				You now have three customization levels:
+			</DocsPageParagraph>
+			<ul className="list-disc space-y-2 pl-5 text-base">
+				<li>
+					<code>classNames</code>: attach your own CSS/Tailwind classes to built-in slots.
+				</li>
+				<li>
+					<code>styles</code>: apply inline style objects to those same slots.
+				</li>
+				<li>
+					<code>components</code>: replace internal UI pieces with custom React components.
+				</li>
+			</ul>
+
+			<DocsPageHeading2>Quick Theming</DocsPageHeading2>
+			<DocsPageParagraph>
+				Use <code>classNames</code> and <code>styles</code> when you want to keep built-in behavior and only adjust presentation.
+			</DocsPageParagraph>
+			<CodeBlock
+				__raw__={`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  classNames={{
+    overlay: 'bg-slate-950/90 backdrop-blur-md',
+    caption: 'bg-slate-950/75',
+    togglePhotoList: 'text-sky-300 hover:text-sky-200',
+    thumbnailButton: 'rounded border border-white/30',
+  }}
+  styles={{
+    photoCounter: { fontVariantNumeric: 'tabular-nums' },
+    caption: { borderTop: '1px solid rgba(255,255,255,0.2)' },
+  }}
+  onClose={() => setOpen(false)}
+/>`}
+			>
+				<pre>
+					<code>{`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  classNames={{
+    overlay: 'bg-slate-950/90 backdrop-blur-md',
+    caption: 'bg-slate-950/75',
+    togglePhotoList: 'text-sky-300 hover:text-sky-200',
+    thumbnailButton: 'rounded border border-white/30',
+  }}
+  styles={{
+    photoCounter: { fontVariantNumeric: 'tabular-nums' },
+    caption: { borderTop: '1px solid rgba(255,255,255,0.2)' },
+  }}
+  onClose={() => setOpen(false)}
+/>`}</code>
+				</pre>
+			</CodeBlock>
+
+			<DocsPageHeading2>Custom Component Slots</DocsPageHeading2>
+			<DocsPageParagraph>
+				Use <code>components</code> when design requirements need custom markup or your own design-system primitives.
+			</DocsPageParagraph>
+			<CodeBlock
+				__raw__={`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  components={{
+    CloseButton: ({ onPress, className }) => (
+      <button
+        type="button"
+        className={\`btn btn-ghost \${className ?? ''}\`}
+        onClick={onPress}
+      >
+        Dismiss
+      </button>
+    ),
+    NextButton: ({ onPress, disabled, className }) => (
+      <button
+        type="button"
+        disabled={disabled}
+        className={\`btn btn-secondary \${className ?? ''}\`}
+        onClick={onPress}
+      >
+        Next
+      </button>
+    ),
+  }}
+  onClose={() => setOpen(false)}
+/>`}
+			>
+				<pre>
+					<code>{`<ReactBnbGallery
+  show={open}
+  photos={photos}
+  components={{
+    CloseButton: ({ onPress, className }) => (
+      <button
+        type="button"
+        className={\`btn btn-ghost \${className ?? ''}\`}
+        onClick={onPress}
+      >
+        Dismiss
+      </button>
+    ),
+    NextButton: ({ onPress, disabled, className }) => (
+      <button
+        type="button"
+        disabled={disabled}
+        className={\`btn btn-secondary \${className ?? ''}\`}
+        onClick={onPress}
+      >
+        Next
+      </button>
+    ),
+  }}
+  onClose={() => setOpen(false)}
+/>`}</code>
+				</pre>
+			</CodeBlock>
+
+			<DocsPageParagraph>
+				For full prop signatures and slot names, see the <Link href="/docs/options">options reference</Link>.
+			</DocsPageParagraph>
+		</DocsPage>
+	);
+}

--- a/docs/components/sidebar-docs.tsx
+++ b/docs/components/sidebar-docs.tsx
@@ -26,6 +26,11 @@ const SIDEBAR_DOCS_SECTIONS = [
 		title: 'Options',
 	},
 	{
+		slug: 'theming',
+		url: '/docs/theming',
+		title: 'Theming',
+	},
+	{
 		slug: 'license',
 		url: '/docs/license',
 		title: 'License',

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/caption.tsx
+++ b/src/components/caption.tsx
@@ -2,29 +2,13 @@ import clsx from 'clsx';
 import type { MouseEvent } from 'react';
 import { memo, useEffect, useRef, useState } from 'react';
 import { defaultPhrases } from '../default-phrases';
-import type {
-	GalleryPhoto,
-	GalleryPhrases,
-	GalleryRenderCaptionActions,
-} from '../types/gallery';
+import type { GalleryCaptionComponentProps } from '../types/gallery';
 import {
 	calculateThumbnailsContainerDimension,
 	calculateThumbnailsLeftScroll,
 } from '../utils/thumbnail-layout';
 import { Thumbnail } from './thumbnail';
 import { TogglePhotoList } from './toggle-photo-list';
-
-/**
- * Props for the gallery caption area and thumbnail strip.
- */
-interface CaptionProps {
-	current?: number;
-	onPress?: (index: number) => void;
-	photos?: GalleryPhoto[];
-	phrases?: GalleryPhrases;
-	renderCaptionActions?: GalleryRenderCaptionActions;
-	showThumbnails?: boolean;
-}
 
 /**
  * Renders the current photo caption and optional thumbnail navigation.
@@ -36,7 +20,11 @@ function Caption({
 	phrases = defaultPhrases,
 	renderCaptionActions,
 	showThumbnails: showThumbnailsProp = true,
-}: CaptionProps) {
+	components,
+}: GalleryCaptionComponentProps) {
+	const ThumbnailComponent = components?.Thumbnail ?? Thumbnail;
+	const TogglePhotoListComponent =
+		components?.TogglePhotoList ?? TogglePhotoList;
 	const [showThumbnails, setShowThumbnails] = useState(showThumbnailsProp);
 	const thumbnailsWrapperRef = useRef<HTMLDivElement | null>(null);
 	const thumbnailsListRef = useRef<HTMLUListElement | null>(null);
@@ -106,7 +94,7 @@ function Caption({
 							<div className="caption-right">
 								<div className="gallery-caption-actions">
 									{hasMoreThanOnePhoto && (
-										<TogglePhotoList
+										<TogglePhotoListComponent
 											phrases={phrases}
 											isOpened={showThumbnails}
 											onPress={toggleThumbnails}
@@ -137,12 +125,12 @@ function Caption({
 									className="thumbnails-list gallery-thumbnails-list"
 									ref={thumbnailsListRef}
 								>
-									{photos.map((photo: GalleryPhoto, index: number) => (
+									{photos.map((photo, index: number) => (
 										<li
 											key={photo.photo || `${index}`}
 											className="gallery-thumbnail-item"
 										>
-											<Thumbnail
+											<ThumbnailComponent
 												active={index === current}
 												photo={photo}
 												onPress={onThumbnailPress}

--- a/src/components/caption.tsx
+++ b/src/components/caption.tsx
@@ -21,6 +21,18 @@ function Caption({
 	renderCaptionActions,
 	showThumbnails: showThumbnailsProp = true,
 	components,
+	className,
+	style,
+	thumbnailsListClassName,
+	thumbnailsListStyle,
+	thumbnailItemClassName,
+	thumbnailItemStyle,
+	thumbnailClassName,
+	thumbnailStyle,
+	thumbnailImageClassName,
+	thumbnailImageStyle,
+	togglePhotoListClassName,
+	togglePhotoListStyle,
 }: GalleryCaptionComponentProps) {
 	const ThumbnailComponent = components?.Thumbnail ?? Thumbnail;
 	const TogglePhotoListComponent =
@@ -58,11 +70,12 @@ function Caption({
 		setShowThumbnails((prevState) => !prevState);
 	};
 
-	const className = clsx(
+	const rootClassName = clsx(
 		'gallery-figcaption',
 		// Legacy alias kept for 2.x compatibility; use `is-thumbnails-collapsed` going forward.
 		!showThumbnails && 'hide',
 		!showThumbnails && 'is-thumbnails-collapsed',
+		className,
 	);
 	const currentPhoto = photos[current];
 	const captionThumbnailsWrapperWidth = calculateThumbnailsContainerDimension(
@@ -78,7 +91,7 @@ function Caption({
 	const hasCaptionRightContent = hasMoreThanOnePhoto || customActions != null;
 
 	return (
-		<figcaption className={className}>
+		<figcaption className={rootClassName} style={style}>
 			<div className="gallery-figcaption--content">
 				<div className="gallery-figcaption--inner">
 					<div className="gallery-figcaption--info">
@@ -98,6 +111,8 @@ function Caption({
 											phrases={phrases}
 											isOpened={showThumbnails}
 											onPress={toggleThumbnails}
+											className={togglePhotoListClassName}
+											style={togglePhotoListStyle}
 										/>
 									)}
 									{customActions != null && (
@@ -122,19 +137,31 @@ function Caption({
 								}}
 							>
 								<ul
-									className="thumbnails-list gallery-thumbnails-list"
+									className={clsx(
+										'thumbnails-list gallery-thumbnails-list',
+										thumbnailsListClassName,
+									)}
+									style={thumbnailsListStyle}
 									ref={thumbnailsListRef}
 								>
 									{photos.map((photo, index: number) => (
 										<li
 											key={photo.photo || `${index}`}
-											className="gallery-thumbnail-item"
+											className={clsx(
+												'gallery-thumbnail-item',
+												thumbnailItemClassName,
+											)}
+											style={thumbnailItemStyle}
 										>
 											<ThumbnailComponent
 												active={index === current}
 												photo={photo}
 												onPress={onThumbnailPress}
 												number={index}
+												className={thumbnailClassName}
+												style={thumbnailStyle}
+												imageClassName={thumbnailImageClassName}
+												imageStyle={thumbnailImageStyle}
 											/>
 										</li>
 									))}

--- a/src/components/close-button.tsx
+++ b/src/components/close-button.tsx
@@ -1,3 +1,5 @@
+import type { GalleryCloseButtonProps } from '../types/gallery';
+
 const CLOSE_PATH =
 	'm23.25 24c-.19 0-.38-.07-.53-.22l-10.72-10.72-10.72 10.72c-.29.29-.77.29-1.06 0s-.29-.77 0-1.06l10.72-10.72-10.72-10.72c-.29-.29-.29-.77 0-1.06s.77-.29 1.06 0l10.72 10.72 10.72-10.72c.29-.29.77-.29 1.06 0s .29.77 0 1.06l-10.72 10.72 10.72 10.72c.29.29.29.77 0 1.06-.15.15-.34.22-.53.22';
 
@@ -8,17 +10,12 @@ const buttonStyle = {
 };
 
 /**
- * Props for the gallery close button.
- */
-interface CloseButtonProps {
-	onPress?: () => void;
-	light?: boolean;
-}
-
-/**
  * Renders the icon button used to close the gallery modal.
  */
-function CloseButton({ onPress, light: _light = false }: CloseButtonProps) {
+function CloseButton({
+	onPress,
+	light: _light = false,
+}: GalleryCloseButtonProps) {
 	return (
 		<button
 			onClick={onPress}

--- a/src/components/close-button.tsx
+++ b/src/components/close-button.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import type { GalleryCloseButtonProps } from '../types/gallery';
 
 const CLOSE_PATH =
@@ -15,11 +16,14 @@ const buttonStyle = {
 function CloseButton({
 	onPress,
 	light: _light = false,
+	className,
+	style,
 }: GalleryCloseButtonProps) {
 	return (
 		<button
 			onClick={onPress}
-			className="gallery-close"
+			className={clsx('gallery-close', className)}
+			style={style}
 			type="button"
 			aria-label="Close gallery"
 			aria-busy={false}

--- a/src/components/control.tsx
+++ b/src/components/control.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import type { CSSProperties } from 'react';
 import { memo, useCallback } from 'react';
 
 const controlStyle = {
@@ -16,6 +17,7 @@ interface ControlProps {
 	className?: string | null;
 	disabled?: boolean;
 	light?: boolean;
+	style?: CSSProperties;
 }
 
 /**
@@ -28,6 +30,7 @@ function Control({
 	className = null,
 	disabled = false,
 	light: _light = false,
+	style,
 }: ControlProps) {
 	const onButtonPress = useCallback(() => {
 		onPress?.();
@@ -40,6 +43,7 @@ function Control({
 			onClick={onButtonPress}
 			disabled={disabled}
 			aria-label={label}
+			style={style}
 		>
 			<svg
 				viewBox="0 0 18 18"

--- a/src/components/gallery.tsx
+++ b/src/components/gallery.tsx
@@ -13,6 +13,7 @@ import {
 import { DIRECTION_NEXT, DIRECTION_PREV } from '../constants';
 import { defaultPhrases } from '../default-phrases';
 import type {
+	GalleryComponents,
 	GalleryController,
 	GalleryPhoto,
 	GalleryPhrases,
@@ -43,6 +44,7 @@ interface GalleryProps {
 	showThumbnails?: boolean;
 	zoomStep?: number;
 	wrap?: boolean;
+	components?: GalleryComponents;
 }
 
 interface TouchInfo {
@@ -172,9 +174,15 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 		showThumbnails = true,
 		zoomStep = 0.25,
 		wrap = false,
+		components,
 	},
 	ref,
 ) {
+	const PrevButtonComponent = components?.PrevButton ?? PrevButton;
+	const NextButtonComponent = components?.NextButton ?? NextButton;
+	const PhotoComponent = components?.Photo ?? Photo;
+	const CaptionComponent = components?.Caption ?? Caption;
+
 	const photoButtonRef = useRef<HTMLButtonElement | null>(null);
 	const photoImageRef = useRef<HTMLImageElement | null>(null);
 	const previousActivePhotoIndexRef = useRef(activePhotoIndex);
@@ -765,7 +773,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 		const ui = [];
 		if (!state.hidePrevButton) {
 			ui.push(
-				<PrevButton
+				<PrevButtonComponent
 					key=".prevControl"
 					disabled={state.controlsDisabled}
 					onPress={onPrevButtonPress}
@@ -775,7 +783,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 		}
 		if (!state.hideNextButton) {
 			ui.push(
-				<NextButton
+				<NextButtonComponent
 					key=".nextControl"
 					disabled={state.controlsDisabled}
 					onPress={onNextButtonPress}
@@ -785,6 +793,8 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 		}
 		return ui;
 	}, [
+		NextButtonComponent,
+		PrevButtonComponent,
 		light,
 		onNextButtonPress,
 		onPrevButtonPress,
@@ -837,7 +847,7 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 					{hasPhotos ? (
 						<div className="gallery-photo">
 							<div className="gallery-photo--current">
-								<Photo
+								<PhotoComponent
 									photo={current}
 									onLoad={onPhotoLoad}
 									onError={onPhotoError}
@@ -866,12 +876,17 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 				</div>
 			</div>
 			{showThumbnails && current && (
-				<Caption
+				<CaptionComponent
 					phrases={phrases}
 					current={state.activePhotoIndex}
 					photos={photos}
 					onPress={onThumbnailPress}
 					renderCaptionActions={renderCaptionActions}
+					showThumbnails={showThumbnails}
+					components={{
+						Thumbnail: components?.Thumbnail,
+						TogglePhotoList: components?.TogglePhotoList,
+					}}
 				/>
 			)}
 		</div>

--- a/src/components/gallery.tsx
+++ b/src/components/gallery.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import type { CSSProperties, MouseEvent, TouchEvent, WheelEvent } from 'react';
 import {
 	forwardRef,
@@ -13,11 +14,13 @@ import {
 import { DIRECTION_NEXT, DIRECTION_PREV } from '../constants';
 import { defaultPhrases } from '../default-phrases';
 import type {
+	GalleryClassNames,
 	GalleryComponents,
 	GalleryController,
 	GalleryPhoto,
 	GalleryPhrases,
 	GalleryRenderCaptionActions,
+	GalleryStyles,
 } from '../types/gallery';
 import { Caption } from './caption';
 import { NextButton } from './next-button';
@@ -45,6 +48,8 @@ interface GalleryProps {
 	zoomStep?: number;
 	wrap?: boolean;
 	components?: GalleryComponents;
+	classNames?: GalleryClassNames;
+	styles?: GalleryStyles;
 }
 
 interface TouchInfo {
@@ -175,6 +180,8 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 		zoomStep = 0.25,
 		wrap = false,
 		components,
+		classNames,
+		styles,
 	},
 	ref,
 ) {
@@ -778,6 +785,8 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 					disabled={state.controlsDisabled}
 					onPress={onPrevButtonPress}
 					light={light}
+					className={classNames?.prevButton}
+					style={styles?.prevButton}
 				/>,
 			);
 		}
@@ -788,6 +797,8 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 					disabled={state.controlsDisabled}
 					onPress={onNextButtonPress}
 					light={light}
+					className={classNames?.nextButton}
+					style={styles?.nextButton}
 				/>,
 			);
 		}
@@ -799,9 +810,13 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 		onNextButtonPress,
 		onPrevButtonPress,
 		photos.length,
+		classNames?.nextButton,
+		classNames?.prevButton,
 		state.controlsDisabled,
 		state.hideNextButton,
 		state.hidePrevButton,
+		styles?.nextButton,
+		styles?.prevButton,
 	]);
 
 	const zoomedPhotoStyle = useMemo(
@@ -839,7 +854,10 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 	const { noPhotosProvided: emptyMessage } = phrases;
 
 	return (
-		<div className="gallery">
+		<div
+			className={clsx('gallery', classNames?.gallery)}
+			style={styles?.gallery}
+		>
 			<div className="gallery-modal--preload">{galleryModalPreloadPhotos}</div>
 			<div className="gallery-main">
 				{controls}
@@ -867,6 +885,10 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 									isZoomMode={isZoomMode}
 									isPanning={state.isPanning}
 									style={zoomedPhotoStyle}
+									buttonClassName={classNames?.photoButton}
+									buttonStyle={styles?.photoButton}
+									imageClassName={classNames?.photoImage}
+									imageStyle={styles?.photoImage}
 								/>
 							</div>
 						</div>
@@ -883,6 +905,18 @@ const Gallery = forwardRef<GalleryController, GalleryProps>(function Gallery(
 					onPress={onThumbnailPress}
 					renderCaptionActions={renderCaptionActions}
 					showThumbnails={showThumbnails}
+					className={classNames?.caption}
+					style={styles?.caption}
+					thumbnailsListClassName={classNames?.thumbnailsList}
+					thumbnailsListStyle={styles?.thumbnailsList}
+					thumbnailItemClassName={classNames?.thumbnailItem}
+					thumbnailItemStyle={styles?.thumbnailItem}
+					thumbnailClassName={classNames?.thumbnailButton}
+					thumbnailStyle={styles?.thumbnailButton}
+					thumbnailImageClassName={classNames?.thumbnailImage}
+					thumbnailImageStyle={styles?.thumbnailImage}
+					togglePhotoListClassName={classNames?.togglePhotoList}
+					togglePhotoListStyle={styles?.togglePhotoList}
 					components={{
 						Thumbnail: components?.Thumbnail,
 						TogglePhotoList: components?.TogglePhotoList,

--- a/src/components/next-button.tsx
+++ b/src/components/next-button.tsx
@@ -1,17 +1,9 @@
 import { memo } from 'react';
+import type { GalleryControlButtonProps } from '../types/gallery';
 import { Control } from './control';
 
 const NEXT_ARROW =
 	'm4.29 1.71a1 1 0 1 1 1.42-1.41l8 8a1 1 0 0 1 0 1.41l-8 8a1 1 0 1 1 -1.42-1.41l7.29-7.29z';
-
-/**
- * Props for the next-navigation control.
- */
-interface NextButtonProps {
-	onPress?: () => void;
-	disabled?: boolean;
-	light?: boolean;
-}
 
 /**
  * Renders the button that advances to the next photo.
@@ -20,7 +12,7 @@ function NextButton({
 	onPress,
 	disabled = false,
 	light = false,
-}: NextButtonProps) {
+}: GalleryControlButtonProps) {
 	return (
 		<Control
 			className="gallery-control--next"

--- a/src/components/next-button.tsx
+++ b/src/components/next-button.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { memo } from 'react';
 import type { GalleryControlButtonProps } from '../types/gallery';
 import { Control } from './control';
@@ -12,15 +13,18 @@ function NextButton({
 	onPress,
 	disabled = false,
 	light = false,
+	className,
+	style,
 }: GalleryControlButtonProps) {
 	return (
 		<Control
-			className="gallery-control--next"
+			className={clsx('gallery-control--next', className)}
 			onPress={onPress}
 			arrow={NEXT_ARROW}
 			label="Next photo"
 			disabled={disabled}
 			light={light}
+			style={style}
 		/>
 	);
 }

--- a/src/components/photo.tsx
+++ b/src/components/photo.tsx
@@ -1,40 +1,8 @@
 import clsx from 'clsx';
-import type {
-	CSSProperties,
-	MouseEvent,
-	Ref,
-	TouchEvent,
-	WheelEvent,
-} from 'react';
 import { memo, useCallback } from 'react';
-import type { GalleryPhoto } from '../types/gallery';
+import type { GalleryPhotoComponentProps } from '../types/gallery';
 import { getCaptionText } from '../utils/get-caption-text';
 import { Image } from './image';
-
-/**
- * Props for the active gallery photo surface.
- */
-interface PhotoProps {
-	photo?: GalleryPhoto | null;
-	onPress?: () => void;
-	onTouchStart?: (event: TouchEvent<HTMLButtonElement>) => void;
-	onTouchMove?: (event: TouchEvent<HTMLButtonElement>) => void;
-	onTouchEnd?: (event: TouchEvent<HTMLButtonElement>) => void;
-	onMouseDown?: (event: MouseEvent<HTMLButtonElement>) => void;
-	onMouseMove?: (event: MouseEvent<HTMLButtonElement>) => void;
-	onMouseUp?: (event: MouseEvent<HTMLButtonElement>) => void;
-	onMouseLeave?: (event: MouseEvent<HTMLButtonElement>) => void;
-	onWheel?: (event: WheelEvent<HTMLButtonElement>) => void;
-	onLoad?: () => void;
-	onError?: () => void;
-	style?: CSSProperties;
-	buttonRef?: Ref<HTMLButtonElement>;
-	imageRef?: Ref<HTMLImageElement>;
-	disablePress?: boolean;
-	enableZoom?: boolean;
-	isZoomMode?: boolean;
-	isPanning?: boolean;
-}
 
 /**
  * Renders the main photo element and forwards interaction callbacks.
@@ -59,7 +27,7 @@ function Photo({
 	enableZoom = true,
 	isZoomMode = false,
 	isPanning = false,
-}: PhotoProps) {
+}: GalleryPhotoComponentProps) {
 	const onPressHandler = useCallback(() => {
 		if (disablePress) {
 			return;

--- a/src/components/photo.tsx
+++ b/src/components/photo.tsx
@@ -21,6 +21,10 @@ function Photo({
 	onLoad,
 	onError,
 	style,
+	buttonClassName,
+	buttonStyle,
+	imageClassName,
+	imageStyle,
 	buttonRef,
 	imageRef,
 	disablePress = false,
@@ -40,6 +44,7 @@ function Photo({
 	}
 
 	const captionText = getCaptionText(photo.caption);
+	const mergedImageStyle = { ...(style || {}), ...(imageStyle || {}) };
 	const className = clsx(
 		'gallery-media-photo',
 		'gallery-media-photo--block',
@@ -59,7 +64,9 @@ function Photo({
 						enableZoom && 'gallery-photo-button--zoom-enabled',
 						isZoomMode && 'gallery-photo-button--zoomed',
 						isPanning && 'gallery-photo-button--panning',
+						buttonClassName,
 					)}
+					style={buttonStyle}
 					onTouchStart={onTouchStart}
 					onTouchMove={onTouchMove}
 					onTouchEnd={onTouchEnd}
@@ -71,11 +78,11 @@ function Photo({
 				>
 					<Image
 						alt={photo.alt || captionText}
-						className="photo gallery-photo-image"
+						className={clsx('photo gallery-photo-image', imageClassName)}
 						src={photo.photo || ''}
 						onLoad={onLoad}
 						onError={onError}
-						style={style}
+						style={mergedImageStyle}
 						imageRef={imageRef}
 					/>
 				</button>

--- a/src/components/prev-button.tsx
+++ b/src/components/prev-button.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { memo } from 'react';
 import type { GalleryControlButtonProps } from '../types/gallery';
 import { Control } from './control';
@@ -12,15 +13,18 @@ function PrevButton({
 	onPress,
 	disabled = false,
 	light = false,
+	className,
+	style,
 }: GalleryControlButtonProps) {
 	return (
 		<Control
-			className="gallery-control--prev"
+			className={clsx('gallery-control--prev', className)}
 			onPress={onPress}
 			arrow={PREV_ARROW}
 			label="Previous photo"
 			disabled={disabled}
 			light={light}
+			style={style}
 		/>
 	);
 }

--- a/src/components/prev-button.tsx
+++ b/src/components/prev-button.tsx
@@ -1,17 +1,9 @@
 import { memo } from 'react';
+import type { GalleryControlButtonProps } from '../types/gallery';
 import { Control } from './control';
 
 const PREV_ARROW =
 	'm13.7 16.29a1 1 0 1 1 -1.42 1.41l-8-8a1 1 0 0 1 0-1.41l8-8a1 1 0 1 1 1.42 1.41l-7.29 7.29z';
-
-/**
- * Props for the previous-navigation control.
- */
-interface PrevButtonProps {
-	onPress?: () => void;
-	disabled?: boolean;
-	light?: boolean;
-}
 
 /**
  * Renders the button that navigates to the previous photo.
@@ -20,7 +12,7 @@ function PrevButton({
 	onPress,
 	disabled = false,
 	light = false,
-}: PrevButtonProps) {
+}: GalleryControlButtonProps) {
 	return (
 		<Control
 			className="gallery-control--prev"

--- a/src/components/thumbnail.tsx
+++ b/src/components/thumbnail.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import type { CSSProperties } from 'react';
 import { memo } from 'react';
 import { THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH } from '../constants';
 import type { GalleryThumbnailComponentProps } from '../types/gallery';
@@ -18,34 +19,44 @@ function Thumbnail({
 	photo = null,
 	onPress,
 	number = 0,
+	className,
+	style,
+	imageClassName,
+	imageStyle,
 }: GalleryThumbnailComponentProps) {
 	if (!photo) {
 		return null;
 	}
 
 	const captionText = getCaptionText(photo.caption);
-	const className = clsx(
+	const buttonClassName = clsx(
 		'thumbnail-button',
 		'gallery-thumbnail-button',
 		// Legacy alias kept for 2.x compatibility; use `is-active` going forward.
 		active && 'active',
 		active && 'is-active',
+		className,
 	);
+	const thumbnailImageStyle = {
+		...thumbnailStyle,
+		...(imageStyle || {}),
+	} satisfies CSSProperties;
 
 	return (
 		<button
 			type="button"
 			aria-label={captionText || undefined}
-			className={className}
+			className={buttonClassName}
 			data-photo-index={number}
 			onClick={onPress}
 			disabled={false}
+			style={style}
 		>
 			<Image
 				alt={photo.thumbnailAlt || photo.alt || captionText}
 				src={photo.thumbnail || photo.photo || ''}
-				className="thumbnail gallery-thumbnail-image"
-				style={thumbnailStyle}
+				className={clsx('thumbnail gallery-thumbnail-image', imageClassName)}
+				style={thumbnailImageStyle}
 			/>
 		</button>
 	);

--- a/src/components/thumbnail.tsx
+++ b/src/components/thumbnail.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { memo } from 'react';
 import { THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH } from '../constants';
-import type { GalleryPhoto } from '../types/gallery';
+import type { GalleryThumbnailComponentProps } from '../types/gallery';
 import { getCaptionText } from '../utils/get-caption-text';
 import { Image } from './image';
 
@@ -11,16 +11,6 @@ const thumbnailStyle = {
 };
 
 /**
- * Props for a single thumbnail button in the caption strip.
- */
-interface ThumbnailProps {
-	active?: boolean;
-	photo?: GalleryPhoto | null;
-	onPress?: (event: React.MouseEvent<HTMLButtonElement>) => void;
-	number?: number;
-}
-
-/**
  * Renders a clickable thumbnail for selecting a photo by index.
  */
 function Thumbnail({
@@ -28,7 +18,7 @@ function Thumbnail({
 	photo = null,
 	onPress,
 	number = 0,
-}: ThumbnailProps) {
+}: GalleryThumbnailComponentProps) {
 	if (!photo) {
 		return null;
 	}

--- a/src/components/toggle-photo-list.tsx
+++ b/src/components/toggle-photo-list.tsx
@@ -1,15 +1,7 @@
 import clsx from 'clsx';
 import { memo } from 'react';
 import { defaultPhrases } from '../default-phrases';
-
-/**
- * Props for the thumbnail list visibility toggle.
- */
-interface TogglePhotoListProps {
-	isOpened?: boolean;
-	onPress?: () => void;
-	phrases?: typeof defaultPhrases;
-}
+import type { GalleryTogglePhotoListComponentProps } from '../types/gallery';
 
 /**
  * Renders the text button that shows or hides the thumbnail strip.
@@ -18,7 +10,7 @@ function TogglePhotoList({
 	isOpened = true,
 	onPress,
 	phrases = defaultPhrases,
-}: TogglePhotoListProps) {
+}: GalleryTogglePhotoListComponentProps) {
 	const { showPhotoList: showLabel, hidePhotoList: hideLabel } = phrases;
 	const label = isOpened ? hideLabel : showLabel;
 	const className = clsx(

--- a/src/components/toggle-photo-list.tsx
+++ b/src/components/toggle-photo-list.tsx
@@ -10,18 +10,26 @@ function TogglePhotoList({
 	isOpened = true,
 	onPress,
 	phrases = defaultPhrases,
+	className,
+	style,
 }: GalleryTogglePhotoListComponentProps) {
 	const { showPhotoList: showLabel, hidePhotoList: hideLabel } = phrases;
 	const label = isOpened ? hideLabel : showLabel;
-	const className = clsx(
+	const toggleClassName = clsx(
 		'gallery-thumbnails--toggle',
 		// Legacy aliases kept for 2.x compatibility; use `is-open` / `is-collapsed` going forward.
 		isOpened ? 'hide' : 'open',
 		isOpened ? 'is-open' : 'is-collapsed',
+		className,
 	);
 
 	return (
-		<button type="button" className={className} onClick={onPress}>
+		<button
+			type="button"
+			className={toggleClassName}
+			onClick={onPress}
+			style={style}
+		>
 			{label}
 		</button>
 	);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,15 @@ export type { ReactBnbGalleryProps } from './react-bnb-gallery';
 
 export type {
 	GalleryCaptionActionsContext,
+	GalleryCaptionComponentProps,
+	GalleryCloseButtonProps,
+	GalleryComponents,
+	GalleryControlButtonProps,
 	GalleryController,
 	GalleryPhoto,
+	GalleryPhotoComponentProps,
 	GalleryPhrases,
 	GalleryRenderCaptionActions,
+	GalleryThumbnailComponentProps,
+	GalleryTogglePhotoListComponentProps,
 } from './types/gallery';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export type { ReactBnbGalleryProps } from './react-bnb-gallery';
 export type {
 	GalleryCaptionActionsContext,
 	GalleryCaptionComponentProps,
+	GalleryClassNames,
 	GalleryCloseButtonProps,
 	GalleryComponents,
 	GalleryControlButtonProps,
@@ -18,6 +19,7 @@ export type {
 	GalleryPhotoComponentProps,
 	GalleryPhrases,
 	GalleryRenderCaptionActions,
+	GalleryStyles,
 	GalleryThumbnailComponentProps,
 	GalleryTogglePhotoListComponentProps,
 } from './types/gallery';

--- a/src/react-bnb-gallery.tsx
+++ b/src/react-bnb-gallery.tsx
@@ -15,11 +15,13 @@ import {
 } from './constants';
 import { defaultPhrases } from './default-phrases';
 import type {
+	GalleryClassNames,
 	GalleryComponents,
 	GalleryController,
 	GalleryPhoto,
 	GalleryPhrases,
 	GalleryRenderCaptionActions,
+	GalleryStyles,
 } from './types/gallery';
 import { normalizePhotos } from './utils/normalize-photos';
 
@@ -54,6 +56,8 @@ export interface ReactBnbGalleryProps {
 	prevButtonPressed?: () => void;
 	renderCaptionActions?: GalleryRenderCaptionActions;
 	components?: GalleryComponents;
+	classNames?: GalleryClassNames;
+	styles?: GalleryStyles;
 	rightKeyPressed?: () => void;
 	maxZoom?: number;
 	show?: boolean;
@@ -84,6 +88,8 @@ export interface ReactBnbGalleryProps {
  * @param prevButtonPressed - Callback fired when the previous button is pressed
  * @param renderCaptionActions - Render prop for injecting custom controls in the caption action area
  * @param components - Optional slot overrides for built-in UI components such as close button, controls, photo, caption, and thumbnails
+ * @param classNames - Optional className overrides for default gallery UI slots
+ * @param styles - Optional inline style overrides for default gallery UI slots
  * @param rightKeyPressed - Callback fired when the right arrow key is pressed
  * @param maxZoom - Maximum zoom scale applied by gestures (default: `3`)
  * @param show - Whether the gallery modal is visible (default: `false`)
@@ -110,6 +116,8 @@ export function ReactBnbGallery({
 	prevButtonPressed,
 	renderCaptionActions,
 	components,
+	classNames,
+	styles,
 	rightKeyPressed,
 	maxZoom = 3,
 	show = false,
@@ -240,8 +248,9 @@ export function ReactBnbGallery({
 			...(hasDeprecatedBackgroundColorOverride
 				? { backgroundColor: backgroundColorProp }
 				: {}),
+			...(styles?.overlay || {}),
 		};
-	}, [backgroundColorProp, opacity]);
+	}, [backgroundColorProp, opacity, styles?.overlay]);
 	const hasMoreThanOnePhoto = photos.length > 1;
 	const photoCounterLabel = `${displayedPhotoIndex + 1} / ${photos.length}`;
 	const CloseButtonComponent = components?.CloseButton ?? CloseButton;
@@ -262,29 +271,51 @@ export function ReactBnbGallery({
 		>
 			<div
 				ref={modalRef}
-				className={clsx('gallery-modal', light && 'mode-light')}
+				className={clsx(
+					'gallery-modal',
+					light && 'mode-light',
+					classNames?.modal,
+				)}
 				onKeyDown={keyboard ? onKeyDown : undefined}
 				tabIndex={-1}
 				role="dialog"
 				aria-modal="true"
-				style={{ zIndex }}
+				style={{ zIndex, ...(styles?.modal || {}) }}
 			>
 				<div
 					style={galleryModalOverlayStyles}
-					className="gallery-modal--overlay"
+					className={clsx('gallery-modal--overlay', classNames?.overlay)}
 				/>
 				<div className="gallery-modal--container">
 					<div className="gallery-modal--table">
 						<div className="gallery-modal--cell">
 							<div className="gallery-modal--content">
-								<div className="gallery-modal--close">
-									<CloseButtonComponent onPress={close} light={light} />
+								<div
+									className={clsx(
+										'gallery-modal--close',
+										classNames?.closeButtonWrapper,
+									)}
+									style={styles?.closeButtonWrapper}
+								>
+									<CloseButtonComponent
+										onPress={close}
+										light={light}
+										className={classNames?.closeButton}
+										style={styles?.closeButton}
+									/>
 								</div>
 								<div className="gallery-content">
 									<div className="gallery-top">
 										<div className="gallery-top--inner">
 											{hasMoreThanOnePhoto && (
-												<p className="gallery-photo-counter" aria-live="polite">
+												<p
+													className={clsx(
+														'gallery-photo-counter',
+														classNames?.photoCounter,
+													)}
+													aria-live="polite"
+													style={styles?.photoCounter}
+												>
 													{photoCounterLabel}
 												</p>
 											)}
@@ -304,6 +335,8 @@ export function ReactBnbGallery({
 										prevButtonPressed={prevButtonPressed}
 										renderCaptionActions={renderCaptionActions}
 										components={components}
+										classNames={classNames}
+										styles={styles}
 										showThumbnails={showThumbnails}
 										preloadSize={preloadSize}
 										maxZoom={maxZoom}

--- a/src/react-bnb-gallery.tsx
+++ b/src/react-bnb-gallery.tsx
@@ -15,6 +15,7 @@ import {
 } from './constants';
 import { defaultPhrases } from './default-phrases';
 import type {
+	GalleryComponents,
 	GalleryController,
 	GalleryPhoto,
 	GalleryPhrases,
@@ -52,6 +53,7 @@ export interface ReactBnbGalleryProps {
 	preloadSize?: number;
 	prevButtonPressed?: () => void;
 	renderCaptionActions?: GalleryRenderCaptionActions;
+	components?: GalleryComponents;
 	rightKeyPressed?: () => void;
 	maxZoom?: number;
 	show?: boolean;
@@ -81,6 +83,7 @@ export interface ReactBnbGalleryProps {
  * @param preloadSize - Number of photos to preload ahead of the active photo (default: `5`)
  * @param prevButtonPressed - Callback fired when the previous button is pressed
  * @param renderCaptionActions - Render prop for injecting custom controls in the caption action area
+ * @param components - Optional slot overrides for built-in UI components such as close button, controls, photo, caption, and thumbnails
  * @param rightKeyPressed - Callback fired when the right arrow key is pressed
  * @param maxZoom - Maximum zoom scale applied by gestures (default: `3`)
  * @param show - Whether the gallery modal is visible (default: `false`)
@@ -106,6 +109,7 @@ export function ReactBnbGallery({
 	preloadSize = 5,
 	prevButtonPressed,
 	renderCaptionActions,
+	components,
 	rightKeyPressed,
 	maxZoom = 3,
 	show = false,
@@ -240,6 +244,7 @@ export function ReactBnbGallery({
 	}, [backgroundColorProp, opacity]);
 	const hasMoreThanOnePhoto = photos.length > 1;
 	const photoCounterLabel = `${displayedPhotoIndex + 1} / ${photos.length}`;
+	const CloseButtonComponent = components?.CloseButton ?? CloseButton;
 
 	if (!show) {
 		return null;
@@ -273,7 +278,7 @@ export function ReactBnbGallery({
 						<div className="gallery-modal--cell">
 							<div className="gallery-modal--content">
 								<div className="gallery-modal--close">
-									<CloseButton onPress={close} light={light} />
+									<CloseButtonComponent onPress={close} light={light} />
 								</div>
 								<div className="gallery-content">
 									<div className="gallery-top">
@@ -298,6 +303,7 @@ export function ReactBnbGallery({
 										nextButtonPressed={nextButtonPressed}
 										prevButtonPressed={prevButtonPressed}
 										renderCaptionActions={renderCaptionActions}
+										components={components}
 										showThumbnails={showThumbnails}
 										preloadSize={preloadSize}
 										maxZoom={maxZoom}

--- a/src/types/gallery.ts
+++ b/src/types/gallery.ts
@@ -48,10 +48,52 @@ export type GalleryRenderCaptionActions = (
 	context: GalleryCaptionActionsContext,
 ) => ReactNode;
 
+/** Class-name overrides for default gallery UI slots. */
+export interface GalleryClassNames {
+	modal?: string;
+	overlay?: string;
+	closeButtonWrapper?: string;
+	closeButton?: string;
+	photoCounter?: string;
+	gallery?: string;
+	prevButton?: string;
+	nextButton?: string;
+	photoButton?: string;
+	photoImage?: string;
+	caption?: string;
+	thumbnailsList?: string;
+	thumbnailItem?: string;
+	thumbnailButton?: string;
+	thumbnailImage?: string;
+	togglePhotoList?: string;
+}
+
+/** Inline style overrides for default gallery UI slots. */
+export interface GalleryStyles {
+	modal?: CSSProperties;
+	overlay?: CSSProperties;
+	closeButtonWrapper?: CSSProperties;
+	closeButton?: CSSProperties;
+	photoCounter?: CSSProperties;
+	gallery?: CSSProperties;
+	prevButton?: CSSProperties;
+	nextButton?: CSSProperties;
+	photoButton?: CSSProperties;
+	photoImage?: CSSProperties;
+	caption?: CSSProperties;
+	thumbnailsList?: CSSProperties;
+	thumbnailItem?: CSSProperties;
+	thumbnailButton?: CSSProperties;
+	thumbnailImage?: CSSProperties;
+	togglePhotoList?: CSSProperties;
+}
+
 /** Props for overriding the modal close button component. */
 export interface GalleryCloseButtonProps {
 	onPress?: () => void;
 	light?: boolean;
+	className?: string;
+	style?: CSSProperties;
 }
 
 /** Shared props for overriding previous/next navigation controls. */
@@ -59,6 +101,8 @@ export interface GalleryControlButtonProps {
 	onPress?: () => void;
 	disabled?: boolean;
 	light?: boolean;
+	className?: string;
+	style?: CSSProperties;
 }
 
 /** Props for overriding the active gallery photo component. */
@@ -76,6 +120,10 @@ export interface GalleryPhotoComponentProps {
 	onLoad?: () => void;
 	onError?: () => void;
 	style?: CSSProperties;
+	buttonClassName?: string;
+	buttonStyle?: CSSProperties;
+	imageClassName?: string;
+	imageStyle?: CSSProperties;
 	buttonRef?: Ref<HTMLButtonElement>;
 	imageRef?: Ref<HTMLImageElement>;
 	disablePress?: boolean;
@@ -89,6 +137,8 @@ export interface GalleryTogglePhotoListComponentProps {
 	isOpened?: boolean;
 	onPress?: () => void;
 	phrases?: GalleryPhrases;
+	className?: string;
+	style?: CSSProperties;
 }
 
 /** Props for overriding the thumbnail item component. */
@@ -97,6 +147,10 @@ export interface GalleryThumbnailComponentProps {
 	photo?: GalleryPhoto | null;
 	onPress?: (event: MouseEvent<HTMLButtonElement>) => void;
 	number?: number;
+	className?: string;
+	style?: CSSProperties;
+	imageClassName?: string;
+	imageStyle?: CSSProperties;
 }
 
 /** Props for overriding the gallery caption component. */
@@ -108,6 +162,18 @@ export interface GalleryCaptionComponentProps {
 	renderCaptionActions?: GalleryRenderCaptionActions;
 	showThumbnails?: boolean;
 	components?: Pick<GalleryComponents, 'Thumbnail' | 'TogglePhotoList'>;
+	className?: string;
+	style?: CSSProperties;
+	thumbnailsListClassName?: string;
+	thumbnailsListStyle?: CSSProperties;
+	thumbnailItemClassName?: string;
+	thumbnailItemStyle?: CSSProperties;
+	thumbnailClassName?: string;
+	thumbnailStyle?: CSSProperties;
+	thumbnailImageClassName?: string;
+	thumbnailImageStyle?: CSSProperties;
+	togglePhotoListClassName?: string;
+	togglePhotoListStyle?: CSSProperties;
 }
 
 /** Slot components that can be overridden to customize gallery UI rendering. */

--- a/src/types/gallery.ts
+++ b/src/types/gallery.ts
@@ -1,4 +1,12 @@
-import type { ReactNode } from 'react';
+import type {
+	ComponentType,
+	CSSProperties,
+	MouseEvent,
+	ReactNode,
+	Ref,
+	TouchEvent,
+	WheelEvent,
+} from 'react';
 import type { DefaultPhrases } from '../default-phrases';
 
 /** Localization strings used throughout the gallery UI. */
@@ -39,6 +47,79 @@ export interface GalleryCaptionActionsContext {
 export type GalleryRenderCaptionActions = (
 	context: GalleryCaptionActionsContext,
 ) => ReactNode;
+
+/** Props for overriding the modal close button component. */
+export interface GalleryCloseButtonProps {
+	onPress?: () => void;
+	light?: boolean;
+}
+
+/** Shared props for overriding previous/next navigation controls. */
+export interface GalleryControlButtonProps {
+	onPress?: () => void;
+	disabled?: boolean;
+	light?: boolean;
+}
+
+/** Props for overriding the active gallery photo component. */
+export interface GalleryPhotoComponentProps {
+	photo?: GalleryPhoto | null;
+	onPress?: () => void;
+	onTouchStart?: (event: TouchEvent<HTMLButtonElement>) => void;
+	onTouchMove?: (event: TouchEvent<HTMLButtonElement>) => void;
+	onTouchEnd?: (event: TouchEvent<HTMLButtonElement>) => void;
+	onMouseDown?: (event: MouseEvent<HTMLButtonElement>) => void;
+	onMouseMove?: (event: MouseEvent<HTMLButtonElement>) => void;
+	onMouseUp?: (event: MouseEvent<HTMLButtonElement>) => void;
+	onMouseLeave?: (event: MouseEvent<HTMLButtonElement>) => void;
+	onWheel?: (event: WheelEvent<HTMLButtonElement>) => void;
+	onLoad?: () => void;
+	onError?: () => void;
+	style?: CSSProperties;
+	buttonRef?: Ref<HTMLButtonElement>;
+	imageRef?: Ref<HTMLImageElement>;
+	disablePress?: boolean;
+	enableZoom?: boolean;
+	isZoomMode?: boolean;
+	isPanning?: boolean;
+}
+
+/** Props for overriding the thumbnail strip visibility toggle component. */
+export interface GalleryTogglePhotoListComponentProps {
+	isOpened?: boolean;
+	onPress?: () => void;
+	phrases?: GalleryPhrases;
+}
+
+/** Props for overriding the thumbnail item component. */
+export interface GalleryThumbnailComponentProps {
+	active?: boolean;
+	photo?: GalleryPhoto | null;
+	onPress?: (event: MouseEvent<HTMLButtonElement>) => void;
+	number?: number;
+}
+
+/** Props for overriding the gallery caption component. */
+export interface GalleryCaptionComponentProps {
+	current?: number;
+	onPress?: (index: number) => void;
+	photos?: GalleryPhoto[];
+	phrases?: GalleryPhrases;
+	renderCaptionActions?: GalleryRenderCaptionActions;
+	showThumbnails?: boolean;
+	components?: Pick<GalleryComponents, 'Thumbnail' | 'TogglePhotoList'>;
+}
+
+/** Slot components that can be overridden to customize gallery UI rendering. */
+export interface GalleryComponents {
+	CloseButton?: ComponentType<GalleryCloseButtonProps>;
+	PrevButton?: ComponentType<GalleryControlButtonProps>;
+	NextButton?: ComponentType<GalleryControlButtonProps>;
+	Photo?: ComponentType<GalleryPhotoComponentProps>;
+	Caption?: ComponentType<GalleryCaptionComponentProps>;
+	Thumbnail?: ComponentType<GalleryThumbnailComponentProps>;
+	TogglePhotoList?: ComponentType<GalleryTogglePhotoListComponentProps>;
+}
 
 /** Exposes navigation controls for programmatic gallery control. */
 export interface GalleryController {

--- a/tests/components/Gallery.test.js
+++ b/tests/components/Gallery.test.js
@@ -326,6 +326,56 @@ describe('Gallery', () => {
 			).not.toBeInTheDocument();
 		});
 
+		it('renders custom internal components passed via components prop', () => {
+			const CustomPrevButton = ({ onPress, disabled }) => (
+				<button
+					type="button"
+					data-testid="custom-prev"
+					onClick={onPress}
+					disabled={disabled}
+				>
+					Prev
+				</button>
+			);
+			const CustomNextButton = ({ onPress, disabled }) => (
+				<button
+					type="button"
+					data-testid="custom-next"
+					onClick={onPress}
+					disabled={disabled}
+				>
+					Next
+				</button>
+			);
+			const CustomPhoto = ({ photo, onPress }) => (
+				<button type="button" data-testid="custom-photo" onClick={onPress}>
+					{photo?.caption || 'photo'}
+				</button>
+			);
+			const CustomCaption = () => (
+				<figcaption data-testid="custom-caption">Custom caption</figcaption>
+			);
+
+			const { getByTestId } = render(
+				<Gallery
+					photos={photos.slice(0, 2)}
+					showThumbnails
+					wrap
+					components={{
+						PrevButton: CustomPrevButton,
+						NextButton: CustomNextButton,
+						Photo: CustomPhoto,
+						Caption: CustomCaption,
+					}}
+				/>,
+			);
+
+			expect(getByTestId('custom-prev')).toBeInTheDocument();
+			expect(getByTestId('custom-next')).toBeInTheDocument();
+			expect(getByTestId('custom-photo')).toBeInTheDocument();
+			expect(getByTestId('custom-caption')).toBeInTheDocument();
+		});
+
 		it('enters zoom mode with mouse wheel and disables click navigation', () => {
 			const activePhotoPressed = vi.fn();
 			const { container } = render(

--- a/tests/components/Gallery.test.js
+++ b/tests/components/Gallery.test.js
@@ -376,6 +376,70 @@ describe('Gallery', () => {
 			expect(getByTestId('custom-caption')).toBeInTheDocument();
 		});
 
+		it('applies classNames and styles to built-in gallery slots', () => {
+			const { container } = render(
+				<Gallery
+					photos={photos.slice(0, 2)}
+					showThumbnails
+					wrap
+					classNames={{
+						gallery: 'custom-gallery',
+						prevButton: 'custom-prev',
+						nextButton: 'custom-next',
+						photoButton: 'custom-photo-button',
+						photoImage: 'custom-photo-image',
+						caption: 'custom-caption',
+						thumbnailsList: 'custom-thumbnails-list',
+						thumbnailItem: 'custom-thumbnail-item',
+						thumbnailButton: 'custom-thumbnail-button',
+						thumbnailImage: 'custom-thumbnail-image',
+						togglePhotoList: 'custom-toggle-photo-list',
+					}}
+					styles={{
+						gallery: { outline: '1px solid rgb(255, 0, 0)' },
+						prevButton: { opacity: 0.7 },
+						photoButton: { outline: '2px solid rgb(0, 255, 0)' },
+						caption: { backgroundColor: 'rgb(0, 0, 0)' },
+					}}
+				/>,
+			);
+
+			expect(container.querySelector('.gallery')).toHaveClass('custom-gallery');
+			expect(container.querySelector('.gallery')).toHaveStyle({
+				outline: '1px solid rgb(255, 0, 0)',
+			});
+			expect(container.querySelector('.gallery-control--prev')).toHaveClass(
+				'custom-prev',
+			);
+			expect(container.querySelector('.gallery-control--next')).toHaveClass(
+				'custom-next',
+			);
+			expect(container.querySelector('.photo-button')).toHaveClass(
+				'custom-photo-button',
+			);
+			expect(container.querySelector('.gallery-photo-image')).toHaveClass(
+				'custom-photo-image',
+			);
+			expect(container.querySelector('.gallery-figcaption')).toHaveClass(
+				'custom-caption',
+			);
+			expect(container.querySelector('.gallery-thumbnails-list')).toHaveClass(
+				'custom-thumbnails-list',
+			);
+			expect(container.querySelector('.gallery-thumbnail-item')).toHaveClass(
+				'custom-thumbnail-item',
+			);
+			expect(container.querySelector('.gallery-thumbnail-button')).toHaveClass(
+				'custom-thumbnail-button',
+			);
+			expect(container.querySelector('.gallery-thumbnail-image')).toHaveClass(
+				'custom-thumbnail-image',
+			);
+			expect(
+				container.querySelector('.gallery-thumbnails--toggle'),
+			).toHaveClass('custom-toggle-photo-list');
+		});
+
 		it('enters zoom mode with mouse wheel and disables click navigation', () => {
 			const activePhotoPressed = vi.fn();
 			const { container } = render(

--- a/tests/components/react-bnb-gallery.test.js
+++ b/tests/components/react-bnb-gallery.test.js
@@ -284,5 +284,55 @@ describe('ReactBnbGallery', () => {
 				document.body.querySelector('.gallery-photo-counter'),
 			).toHaveTextContent('2 / 2');
 		});
+
+		it('applies classNames and styles overrides to modal slots', () => {
+			render(
+				<ReactBnbGallery
+					photos={photos.slice(0, 2)}
+					show
+					classNames={{
+						modal: 'custom-modal',
+						overlay: 'custom-overlay',
+						closeButton: 'custom-close',
+						photoCounter: 'custom-counter',
+					}}
+					styles={{
+						modal: { outline: '2px solid rgb(255, 0, 0)' },
+						overlay: { backdropFilter: 'blur(2px)' },
+						closeButton: { borderRadius: '12px' },
+						photoCounter: { letterSpacing: '0.2em' },
+					}}
+				/>,
+			);
+
+			expect(document.body.querySelector('.gallery-modal')).toHaveClass(
+				'custom-modal',
+			);
+			expect(document.body.querySelector('.gallery-modal')).toHaveStyle({
+				outline: '2px solid rgb(255, 0, 0)',
+			});
+			expect(
+				document.body.querySelector('.gallery-modal--overlay'),
+			).toHaveClass('custom-overlay');
+			expect(
+				document.body.querySelector('.gallery-modal--overlay'),
+			).toHaveStyle({
+				backdropFilter: 'blur(2px)',
+			});
+			expect(document.body.querySelector('.gallery-close')).toHaveClass(
+				'custom-close',
+			);
+			expect(document.body.querySelector('.gallery-close')).toHaveStyle({
+				borderRadius: '12px',
+			});
+			expect(document.body.querySelector('.gallery-photo-counter')).toHaveClass(
+				'custom-counter',
+			);
+			expect(document.body.querySelector('.gallery-photo-counter')).toHaveStyle(
+				{
+					letterSpacing: '0.2em',
+				},
+			);
+		});
 	});
 });

--- a/tests/components/react-bnb-gallery.test.js
+++ b/tests/components/react-bnb-gallery.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import { ReactBnbGallery } from '../../src/react-bnb-gallery';
 
@@ -241,6 +241,48 @@ describe('ReactBnbGallery', () => {
 				}),
 			);
 			expect(document.body).toHaveTextContent('Custom 1');
+		});
+
+		it('supports overriding UI components via the components prop', () => {
+			const onClose = vi.fn();
+			const CustomCloseButton = ({ onPress }) => (
+				<button type="button" data-testid="custom-close" onClick={onPress}>
+					Close
+				</button>
+			);
+			const CustomThumbnail = ({ number = 0, onPress }) => (
+				<button
+					type="button"
+					data-testid={`custom-thumbnail-${number}`}
+					data-photo-index={number}
+					onClick={onPress}
+				>
+					Thumb {number + 1}
+				</button>
+			);
+
+			render(
+				<ReactBnbGallery
+					photos={photos.slice(0, 2)}
+					show
+					onClose={onClose}
+					components={{
+						CloseButton: CustomCloseButton,
+						Thumbnail: CustomThumbnail,
+					}}
+				/>,
+			);
+
+			fireEvent.click(screen.getByTestId('custom-close'));
+			expect(onClose).toHaveBeenCalledTimes(1);
+
+			expect(
+				document.body.querySelector('.gallery-photo-counter'),
+			).toHaveTextContent('1 / 2');
+			fireEvent.click(screen.getByTestId('custom-thumbnail-1'));
+			expect(
+				document.body.querySelector('.gallery-photo-counter'),
+			).toHaveTextContent('2 / 2');
 		});
 	});
 });


### PR DESCRIPTION
## Summary
This PR improves customization DX in v3 by adding two complementary APIs:

- `components`: replace internal UI slots with custom React components.
- `classNames` and `styles`: lightweight visual customization of built-in slots without replacing behavior.

It also documents these capabilities in both the options reference and a dedicated Theming page.

## What Changed
### 1) Slot overrides (`components`)
Added `components?: GalleryComponents` to `ReactBnbGallery` with support for:
- `CloseButton`
- `PrevButton`
- `NextButton`
- `Photo`
- `Caption`
- `Thumbnail`
- `TogglePhotoList`

### 2) Lightweight theming (`classNames`, `styles`)
Added:
- `classNames?: GalleryClassNames`
- `styles?: GalleryStyles`

These are wired across modal, overlay, controls, photo, caption, thumbnails, and toggle slots.

### 3) Public typing surface
Exported customization-related types from package entrypoint, including:
- `GalleryComponents`
- `GalleryClassNames`
- `GalleryStyles`
- Slot prop interfaces for component overrides

### 4) Docs
- Updated `/docs/options` with `components`, `classNames`, and `styles` usage.
- Added dedicated `/docs/theming` page with practical examples.
- Added Theming nav entry in docs sidebar.

### 5) Release metadata
- Added changeset: `.changeset/soft-oranges-listen.md` (`minor`)

## Migration / Compatibility Notes
- Existing consumers are unaffected unless they opt into new props.
- No breaking API change introduced in this PR.
- `components` is for structural/custom-markup integration.
- `classNames`/`styles` are recommended for straightforward visual customization.

## Validation
Executed locally:
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm docs:build`

All passed.